### PR TITLE
Feature/custom selections and expands

### DIFF
--- a/sampleapp/sample.tsx
+++ b/sampleapp/sample.tsx
@@ -25,14 +25,22 @@ oneNoteDataProvider.getNotebooks().then((notebooks) => {
 			oneNoteDataProvider: oneNoteDataProvider,
 			notebookListUpdater: updater,
 			callbacks: {
+				// TODO we should be able to clean up this boilerplate
 				onNotebookHierarchyUpdated: (newNotebookHierarchy) => {
 					render(globalProps, newNotebookHierarchy);
 				},
+				// onNotebookSelected: (notebook) => {
+				// 	globalProps.globals.selectedId = notebook.id;
+				// 	render(globalProps, globalProps.globals.notebookListUpdater.get());
+				// },
 				onSectionSelected: (section) => {
 					globalProps.globals.selectedId = section.id;
 					render(globalProps, globalProps.globals.notebookListUpdater.get());
 				},
-				onPageSelected: (page) => { }
+				onPageSelected: (page) => {
+					globalProps.globals.selectedId = page.id;
+					render(globalProps, globalProps.globals.notebookListUpdater.get());
+				}
 			},
 			selectedId: undefined
 		}

--- a/sampleapp/sampleOneNoteDataProvider.ts
+++ b/sampleapp/sampleOneNoteDataProvider.ts
@@ -219,8 +219,8 @@ class SampleOneNoteDataProvider implements OneNoteDataProvider {
 		return Promise.resolve(notebooks);
 	}
 
-  getPages(sectionId: string): Promise<Page[]> {
-    let id = '' + (Math.floor(Math.random() * 500000));
+	getPages(sectionId: string): Promise<Page[]> {
+		let id = '' + (Math.floor(Math.random() * 500000));
 		let pages = [{ id: id, title: 'Page:' + id }];
 		return Promise.resolve(pages);
 	}

--- a/sampleapp/sampleOneNoteDataProvider.ts
+++ b/sampleapp/sampleOneNoteDataProvider.ts
@@ -219,8 +219,9 @@ class SampleOneNoteDataProvider implements OneNoteDataProvider {
 		return Promise.resolve(notebooks);
 	}
 
-	getPages(sectionId: string): Promise<Page[]> {
-		let pages = [{ id: 'id', title: 'Page!' }];
+  getPages(sectionId: string): Promise<Page[]> {
+    let id = '' + (Math.floor(Math.random() * 500000));
+		let pages = [{ id: id, title: 'Page:' + id }];
 		return Promise.resolve(pages);
 	}
 }

--- a/src/components/notebookItem.tsx
+++ b/src/components/notebookItem.tsx
@@ -19,12 +19,31 @@ class NotebookItem extends React.Component<NotebookItemProps, NotebookItemState>
 		this.state = { expanded: props.expanded };
 	}
 
-	render() {
-		let { expanded } = this.state;
+	private onClick() {
+		let onNotebookSelected = this.props.globals.callbacks.onNotebookSelected;
+		if (!!onNotebookSelected) {
+			onNotebookSelected(this.props.notebook);
+		}
 
+		// We are only interested in expanding if either sections/pages are deemed selectable
+		if (this.isExpandable()) {
+			this.setState({ expanded: !this.state.expanded });
+		}
+	}
+
+	private isExpandable(): boolean {
+		let callbacks = this.props.globals.callbacks;
+		return !!callbacks.onSectionSelected || !!callbacks.onPageSelected;
+	}
+
+	private isSelected(): boolean {
+		return this.props.globals.selectedId === this.props.notebook.id;
+	}
+
+	render() {
 		return (
 			<li>
-				<a onClick={() => this.setState({ expanded: !expanded })}>
+				<a className={this.isSelected() ? 'picker-selectedItem' : ''} onClick={this.onClick.bind(this)}>
 					<span className='ms-font-l ms-fontWeight-regular ms-fontColor-themePrimary'>
 						<i className='picker-icon-left ms-Icon ms-Icon--OneNoteLogo'></i>
 						{this.props.notebook.name}

--- a/src/components/pageItem.tsx
+++ b/src/components/pageItem.tsx
@@ -9,15 +9,20 @@ interface PageItemProps extends GlobalProps {
 
 class PageItem extends React.Component<PageItemProps, null> {
 	private onClick() {
-		this.props.globals.callbacks.onPageSelected(this.props.page);
+		let onPageSelected = this.props.globals.callbacks.onPageSelected;
+		if (!!onPageSelected) {
+			onPageSelected(this.props.page);
+		}
+	}
+
+	private isSelected(): boolean {
+		return this.props.globals.selectedId === this.props.page.id;
 	}
 
 	render() {
-		let selected = this.props.globals.selectedId === this.props.page.id;
-
 		return (
 			<li>
-				<a className={selected ? 'picker-selectedItem' : ''} onClick={this.onClick.bind(this)}>
+				<a className={this.isSelected() ? 'picker-selectedItem' : ''} onClick={this.onClick.bind(this)}>
 					<span className='ms-font-m ms-fontWeight-regular ms-fontColor-themePrimary'>
 						<i className='picker-icon-left ms-Icon ms-Icon--Page'></i>
 						{this.props.page.title}

--- a/src/components/sectionGroupItem.tsx
+++ b/src/components/sectionGroupItem.tsx
@@ -18,12 +18,22 @@ class SectionGroupItem extends React.Component<SectionGroupItemProps, SectionGro
 		this.state = { expanded: props.expanded };
 	}
 
-	render() {
-		let { expanded } = this.state;
+	private onClick() {
+		// We are only interested in expanding if either sections/pages are deemed selectable
+		if (this.isExpandable()) {
+			this.setState({ expanded: !this.state.expanded });
+		}
+	}
 
+	private isExpandable(): boolean {
+		let callbacks = this.props.globals.callbacks;
+		return !!callbacks.onSectionSelected || !!callbacks.onPageSelected;
+	}
+
+	render() {
 		return (
 			<li>
-				<a onClick={() => this.setState({ expanded: !expanded })}>
+				<a onClick={this.onClick.bind(this)}>
 					<span className='ms-font-m-plus ms-fontWeight-semibold ms-fontColor-themePrimary'>
 						<i className='picker-icon-left ms-Icon ms-Icon--Sections'></i>
 						{this.props.sectionGroup.name}

--- a/src/props/oneNotePickerCallbacks.ts
+++ b/src/props/oneNotePickerCallbacks.ts
@@ -6,12 +6,20 @@ import Page from '../oneNoteDataStructures/page';
  * Represents a set of callbacks that the application can register to be
  * notified whenever an 'interesting' synchronous or asynchronous user action
  * happens. The rendering application can choose to act on this new information
- * (e.g., a re-render of the OneNotePicker, logging).
+ * (e.g., a re-render of the OneNotePicker, logging). If a selection callback
+ * is specified for a particular OneNote item type, the picker will assume that
+ * it is selectable. If a selection callback is not specified, the picker will
+ * assume the opposite. The picker will only allow items to be expandable until
+ * the deepest selectable object. There should be at least one selection callback
+ * specified.
  */
 interface OneNotePickerCallbacks {
 	onNotebookHierarchyUpdated: (notebooks: Notebook[]) => void;
-	onSectionSelected: (section: Section) => void;
-	onPageSelected: (page: Page) => void;
+
+	// Selection callbacks
+	onNotebookSelected?: (notebook: Notebook) => void;
+	onSectionSelected?: (section: Section) => void;
+	onPageSelected?: (page: Page) => void;
 }
 
 export default OneNotePickerCallbacks;

--- a/test/props/mockProps.ts
+++ b/test/props/mockProps.ts
@@ -15,9 +15,10 @@ class MockProps {
 				oneNoteDataProvider: oneNoteDataProvider,
 				notebookListUpdater: updater,
 				callbacks: {
-					onNotebookHierarchyUpdated: () => {},
-					onSectionSelected: () => {},
-					onPageSelected: () => {}
+					onNotebookHierarchyUpdated: () => { },
+					onNotebookSelected: () => { },
+					onSectionSelected: () => { },
+					onPageSelected: () => { }
 				},
 				selectedId: undefined
 			}


### PR DESCRIPTION
- Allow the developer to specify what is selectable in the picker (notebooks, sections, pages, NOT sectiongroups)
- The picker will now only expand to the deepest selectable item type. For example, if the deepest selectable item is the section type, then we won't expand sections to reveal pages. This also means we don't call our API for pages unecessarily.

There's a tiny bit of cleanup needed, and tests to be written, but I'm hoping to get this in to avoid large conflicts in the near future.