### PR TITLE
Allow dev to add timeout and header overrides to OneNoteApiDataProvider

### DIFF
--- a/src/providers/oneNoteApiDataProvider.ts
+++ b/src/providers/oneNoteApiDataProvider.ts
@@ -11,8 +11,8 @@ export class OneNoteApiDataProvider implements OneNoteDataProvider {
 	private api: OneNoteApi.IOneNoteApi;
 	private responseTransformer: OneNoteApiResponseTransformer;
 
-	constructor(authToken: string) {
-		this.api = new OneNoteApi.OneNoteApi(authToken);
+	constructor(authToken: string, timeout?: number, headers?: { [key: string]: string }) {
+		this.api = new OneNoteApi.OneNoteApi(authToken, timeout, headers);
 		this.responseTransformer = new OneNoteApiResponseTransformer();
 	}
 


### PR DESCRIPTION
This will allow us to specify headers like "MS-Int-AppId"