### PR TITLE
Replace null state with empty object in OneNotePicker component

### DIFF
--- a/src/oneNotePicker.tsx
+++ b/src/oneNotePicker.tsx
@@ -14,7 +14,7 @@ export interface OneNotePickerProps extends GlobalProps {
 	notebooks: Notebook[];
 }
 
-export class OneNotePicker extends React.Component<OneNotePickerProps, null> {
+export class OneNotePicker extends React.Component<OneNotePickerProps, {}> {
 	render() {
 		let notebookRenderStrategies: ExpandableNodeRenderStrategy[] =
 			this.props.notebooks.map(notebook => new NotebookRenderStrategy(notebook, this.props.globals));


### PR DESCRIPTION
Fixes build issue as null states are disallowed (states and props should never be null, and should be at the very least an empty object)