### PR TITLE
Bug/fix endless shared notebook spinner on notfound

### DIFF
--- a/sampleApp/sampleOneNoteDataProvider.ts
+++ b/sampleApp/sampleOneNoteDataProvider.ts
@@ -208,7 +208,7 @@ export class SampleOneNoteDataProvider implements OneNoteDataProvider {
 		return Promise.resolve([]);
 	}
 
-	getSpNotebookProperties(spNotebook: SharedNotebook, expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<SharedNotebookApiProperties> {
+	getSpNotebookProperties(spNotebook: SharedNotebook, expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<SharedNotebookApiProperties | undefined> {
 		return Promise.resolve({
 			id: '',
 			sectionGroups: [],

--- a/src/components/sharedNotebookRenderStrategy.tsx
+++ b/src/components/sharedNotebookRenderStrategy.tsx
@@ -114,6 +114,11 @@ export class SharedNotebookRenderStrategy implements ExpandableNodeRenderStrateg
 				// fetched any metadata or children info
 				this.notebook.startedLoading = true;
 				this.globals.oneNoteDataProvider.getSpNotebookProperties(this.notebook, 5, true).then((apiProperties) => {
+					if (!apiProperties) {
+						this.notebook.apiHttpErrorCode = 404;
+						return;
+					}
+
 					this.notebook.apiProperties = apiProperties;
 
 					if (this.globals.notebookListUpdater) {

--- a/src/components/treeView/expandableNode.tsx
+++ b/src/components/treeView/expandableNode.tsx
@@ -91,7 +91,7 @@ export class ExpandableNode extends React.Component<ExpandableNodeProps, Expanda
 					{this.props.node.element()}
 				</a>
 				{this.state.expanded ?
-					<ul role='group' aria-label={this.props.node.getName()}>
+					<ul role='group'>
 						{this.props.node.getChildren(this.level + 1)}
 					</ul> : undefined}
 			</li>);

--- a/src/providers/oneNoteApiDataProvider.ts
+++ b/src/providers/oneNoteApiDataProvider.ts
@@ -118,7 +118,7 @@ export class OneNoteApiDataProvider implements OneNoteDataProvider {
 		return decodeURIComponent(last);
 	}
 
-	getSpNotebookProperties(spNotebook: SharedNotebook, expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<SharedNotebookApiProperties> {
+	getSpNotebookProperties(spNotebook: SharedNotebook, expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<SharedNotebookApiProperties | undefined> {
 		// These both return an array of XMLHttpRequest on the rejection case. The caller
 		// can then decide which error is most significant.
 		return this.getSiteIds(spNotebook.webUrl).then((ids) => {
@@ -163,7 +163,7 @@ export class OneNoteApiDataProvider implements OneNoteDataProvider {
 		});
 	}
 
-	private getSpNotebookPropertiesUsingSiteIds(spNotebook: SharedNotebook, siteId: string, siteCollectionId: string, expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<SharedNotebookApiProperties> {
+	private getSpNotebookPropertiesUsingSiteIds(spNotebook: SharedNotebook, siteId: string, siteCollectionId: string, expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<SharedNotebookApiProperties | undefined> {
 		// Don't add a service-side name filter as the notebook name could have changed
 		let url = `https://www.onenote.com/api/v1.0/myOrganization/siteCollections/${siteCollectionId}/sites/${siteId}/notes/notebooks`;
 		url += `?${this.getExpands(expands)}`;
@@ -182,7 +182,7 @@ export class OneNoteApiDataProvider implements OneNoteDataProvider {
 					}
 
 					if (!matchingNotebook) {
-						reject(xhr);
+						resolve(undefined);
 						return;
 					}
 
@@ -197,7 +197,7 @@ export class OneNoteApiDataProvider implements OneNoteDataProvider {
 					});
 					return;
 				}
-				reject(xhr);
+				reject([xhr]);
 			}).catch((xhr) => {
 				reject([xhr]);
 			});

--- a/src/providers/oneNoteApiDataProvider.ts
+++ b/src/providers/oneNoteApiDataProvider.ts
@@ -92,9 +92,9 @@ export class OneNoteApiDataProvider implements OneNoteDataProvider {
 			let webUrl: string = notebook.links.oneNoteWebUrl.href;
 			let segments = webUrl.split('/');
 			if (segments.length > 2) {
-				// TODO (machiam) this is somewhat naive, but we want to filter out ppe
+				// This is somewhat naive, but we want to filter out ppe and live
 				let domain = segments[2];
-				return domain.indexOf('.spoppe.') < 0;
+				return domain.indexOf('.spoppe.') < 0 && domain !== 'd.docs.live.net';
 			}
 		}
 		return false;

--- a/src/providers/oneNoteDataProvider.ts
+++ b/src/providers/oneNoteDataProvider.ts
@@ -12,5 +12,5 @@ export interface OneNoteDataProvider {
 	getPages(section: Section): Promise<Page[]>;
 
 	getSpNotebooks(): Promise<SharedNotebook[]>;
-	getSpNotebookProperties(spNotebook: SharedNotebook, expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<SharedNotebookApiProperties>;
+	getSpNotebookProperties(spNotebook: SharedNotebook, expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<SharedNotebookApiProperties | undefined>;
 }


### PR DESCRIPTION
- Fix endless shared notebook spinner if the notebook no longer exists but the GET call returned 200
- Filter out shared live notebooks as we can't query them
- VO fix to prevent expanded notebook names from being read twice