### PR TITLE
Provide some new widgets, allow more styling overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+package-lock.json
 
 # testing
 /coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenote-picker",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "private": true,
   "dependencies": {
     "bulma": "^0.4.2",

--- a/src/components/notebookRenderStrategy.tsx
+++ b/src/components/notebookRenderStrategy.tsx
@@ -6,7 +6,6 @@ import {ExpandableNodeRenderStrategy} from './treeView/expandableNodeRenderStrat
 import {ExpandableNode} from './treeView/expandableNode';
 import {LeafNode} from './treeView/leafNode';
 import {Constants} from '../constants';
-import {Strings} from '../strings';
 import {Notebook} from '../oneNoteDataStructures/notebook';
 import {OneNoteItemUtils} from '../oneNoteDataStructures/oneNoteItemUtils';
 import {InnerGlobals} from '../props/globalProps';
@@ -20,9 +19,7 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 		return (
 			<div className={this.isSelected() ? 'picker-selectedItem' : ''} title={this.notebook.name}>
 				<div className='picker-icon-left'>
-					<img
-						src={require('../images/notebook_icon.png')}
-						alt={Strings.get('Accessibility.NotebookIcon', this.globals.strings)}/>
+					<i className='ms-Icon ms-Icon--OneNoteLogo' aria-hidden='true'></i>
 				</div>
 				<div>
 					<label className='ms-fontSize-sPlus'>{this.notebook.name}</label>

--- a/src/components/notebookRenderStrategy.tsx
+++ b/src/components/notebookRenderStrategy.tsx
@@ -6,6 +6,7 @@ import {ExpandableNodeRenderStrategy} from './treeView/expandableNodeRenderStrat
 import {ExpandableNode} from './treeView/expandableNode';
 import {LeafNode} from './treeView/leafNode';
 import {Constants} from '../constants';
+import {Strings} from '../strings';
 import {Notebook} from '../oneNoteDataStructures/notebook';
 import {OneNoteItemUtils} from '../oneNoteDataStructures/oneNoteItemUtils';
 import {InnerGlobals} from '../props/globalProps';
@@ -19,7 +20,9 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 		return (
 			<div className={this.isSelected() ? 'picker-selectedItem' : ''} title={this.notebook.name}>
 				<div className='picker-icon-left'>
-					<i className='ms-Icon ms-Icon--OneNoteLogo' aria-hidden='true'></i>
+					<img
+						src={require('../images/notebook_icon.png')}
+						alt={Strings.get('Accessibility.NotebookIcon', this.globals.strings)}/>
 				</div>
 				<div>
 					<label className='ms-fontSize-sPlus'>{this.notebook.name}</label>

--- a/src/components/sectionGroupRenderStrategy.tsx
+++ b/src/components/sectionGroupRenderStrategy.tsx
@@ -5,7 +5,6 @@ import {ExpandableNodeRenderStrategy} from './treeView/expandableNodeRenderStrat
 import {ExpandableNode} from './treeView/expandableNode';
 import {LeafNode} from './treeView/leafNode';
 import {Constants} from '../constants';
-import {Strings} from '../strings';
 import {SectionGroup} from '../oneNoteDataStructures/sectionGroup';
 import {InnerGlobals} from '../props/globalProps';
 
@@ -18,9 +17,19 @@ export class SectionGroupRenderStrategy implements ExpandableNodeRenderStrategy 
 		return (
 			<div title={this.sectionGroup.name}>
 				<div className='picker-icon-left'>
-					<img
-						src={require('../images/sectiongroup_icon.png')}
-						alt={Strings.get('Accessibility.SectionGroupIcon', this.globals.strings)}/>
+				<svg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink' x='0px' y='0px'
+					viewBox='0 0 20 20' style={{enableBackground: 'new 0 0 20 20'}} xmlSpace='preserve'>
+						<style type='text/css'>
+							{'.st0 { fill:none;}'}
+						</style>
+						<g>
+							<g>
+								<rect y='0' className='st0' width='20' height='20'/>
+								<path d='M13,3H7v14h6v2h1V1h-1V3z'/>
+							</g>
+							<polygon points='11,1 5,1 5,15 6,15 6,2 11,2   '/>
+						</g>
+				</svg>
 				</div>
 				<div>
 					<label className='ms-fontSize-sPlus'>{this.sectionGroup.name}</label>

--- a/src/components/sectionRenderStrategy.tsx
+++ b/src/components/sectionRenderStrategy.tsx
@@ -4,7 +4,6 @@ import {PageRenderStrategy} from './pageRenderStrategy';
 import {ExpandableNodeRenderStrategy} from './treeView/expandableNodeRenderStrategy';
 import {LeafNode} from './treeView/leafNode';
 import {Constants} from '../constants';
-import {Strings} from '../strings';
 import {Section} from '../oneNoteDataStructures/section';
 import {OneNoteItemUtils} from '../oneNoteDataStructures/oneNoteItemUtils';
 import {InnerGlobals} from '../props/globalProps';
@@ -18,9 +17,16 @@ export class SectionRenderStrategy implements ExpandableNodeRenderStrategy {
 		return (
 			<div className={this.isSelected() ? 'picker-selectedItem' : ''} title={this.section.name}>
 				<div className='picker-icon-left'>
-					<img
-						src={require('../images/section_icon.png')}
-						alt={Strings.get('Accessibility.SectionIcon', this.globals.strings)}/>
+				<svg version='1.1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink' x='0px' y='0px'
+					viewBox='0 0 20 20' style={{enableBackground: 'new 0 0 20 20'}} xmlSpace='preserve'>
+					<style type='text/css'>
+						{'.st0 { fill:none;}'}
+					</style>
+					<g>
+						<rect y='0' className='st0' width='20' height='20' />
+						<path d='M12,3H6v14h6v2h1V1h-1V3z'/>
+					</g>
+				</svg>
 				</div>
 				<div>
 					<label className='ms-fontSize-sPlus'>{this.section.name}</label>

--- a/src/oneNoteDataStructures/oneNoteApiResponseTransformer.ts
+++ b/src/oneNoteDataStructures/oneNoteApiResponseTransformer.ts
@@ -59,8 +59,8 @@ export class OneNoteApiResponseTransformer {
 			expanded: this.defaultExpanded,
 			pages: [],
 			apiUrl: section.self,
-			webUrl: sectionAsAny && sectionAsAny.links && sectionAsAny.oneNoteWebUrl && sectionAsAny.links.oneNoteWebUrl.href as string || undefined,
-			clientUrl: sectionAsAny && sectionAsAny.links && sectionAsAny.oneNoteClientUrl && sectionAsAny.links.oneNoteClientUrl.href as string || undefined
+			webUrl: sectionAsAny && sectionAsAny.links && sectionAsAny.links.oneNoteWebUrl && sectionAsAny.links.oneNoteWebUrl.href as string || undefined,
+			clientUrl: sectionAsAny && sectionAsAny.links && sectionAsAny.links.oneNoteClientUrl && sectionAsAny.links.oneNoteClientUrl.href as string || undefined
 		};
 
 		transformed.pages = !!section.pages ? section.pages.map(page => this.transformPage(page, transformed)) : undefined;

--- a/src/oneNoteDataStructures/oneNoteItemUtils.ts
+++ b/src/oneNoteDataStructures/oneNoteItemUtils.ts
@@ -99,3 +99,5 @@ export class OneNoteItemUtils {
 		return ancestry;
 	}
 }
+
+export * from './oneNoteApiResponseTransformer';

--- a/src/oneNotePicker.scss
+++ b/src/oneNotePicker.scss
@@ -120,3 +120,51 @@
 		margin: 1px;
 	}
 }
+
+// TODO (machiam) Maybe be a different file?
+.picker-dropdown {
+	position: relative;
+	text-align: left;
+	cursor: pointer;
+	text-decoration: none;
+
+	.picker-dropdown-padding {
+		border: 1px solid rgba(22, 35, 58, 0.26);
+		padding: 5px;
+	}
+
+	.picker-popup {
+		position: absolute;
+		overflow-y: auto;
+		background-color: #FFFFFF;
+		border: 1px solid rgba(22, 35, 58, 0.26);
+		max-height: 140px;
+	}
+
+	.popup-upwards {
+		bottom: 100%;
+	}
+
+	.dropdown-arrow-container {
+		height: 14px;
+		width: 18px;
+		float: right;
+		padding-right: 12px;
+
+		svg {
+			height: auto;
+			width: 18px;
+		}
+	}
+
+	.picker-dropdown-toggle-label {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		padding: 1px 1px 1px 12px;
+	}
+
+	.dropdown-arrow-container svg polygon {
+		fill: #444545;
+	}
+}

--- a/src/oneNotePicker.tsx
+++ b/src/oneNotePicker.tsx
@@ -57,3 +57,4 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, {}> {
 }
 
 export * from './oneNoteSingleNotebookPicker';
+export * from './oneNoteSingleNotebookDropdown';

--- a/src/oneNotePicker.tsx
+++ b/src/oneNotePicker.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 
 import './oneNotePicker.scss';
 
-import {Constants} from './constants';
-import {Strings} from './strings';
+import {OneNotePickerBase} from './oneNotePickerBase';
 import {NotebookRenderStrategy} from './components/notebookRenderStrategy';
 import {SharedNotebookRenderStrategy} from './components/sharedNotebookRenderStrategy';
 import {ExpandableNode} from './components/treeView/expandableNode';
@@ -18,57 +17,43 @@ export interface OneNotePickerProps extends GlobalProps {
 	sharedNotebooks?: SharedNotebook[];
 }
 
-export class OneNotePicker extends React.Component<OneNotePickerProps, {}> {
-	private get treeViewId() {
-		return Constants.TreeView.id;
-	}
+export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, {}> {
+	protected get rootNodes(): JSX.Element[] {
+		const { notebooks, sharedNotebooks, globals } = this.props;
+		const { focusOnMount, ariaSelectedId } = globals;
 
-	private get activeDescendentId() {
-		if (!this.props.globals.ariaSelectedId) {
-			return '';
-		}
-		return this.treeViewId + this.props.globals.ariaSelectedId;
-	}
-
-	render() {
-		let { notebooks, sharedNotebooks, globals } = this.props;
-		let { focusOnMount, ariaSelectedId } = globals;
-
-		let notebookRenderStrategies: ExpandableNodeRenderStrategy[] =
+		const notebookRenderStrategies: ExpandableNodeRenderStrategy[] =
 			notebooks.map(notebook => new NotebookRenderStrategy(notebook, globals));
 		
-		let sharedNotebookRenderStrategies: ExpandableNodeRenderStrategy[] = sharedNotebooks ?
+		const sharedNotebookRenderStrategies: ExpandableNodeRenderStrategy[] = sharedNotebooks ?
 			sharedNotebooks.map(sharedNotebook => new SharedNotebookRenderStrategy(sharedNotebook, globals)) : [];
 
 		const noPersonalNotebooks = notebookRenderStrategies.length === 0;
 
-		return (
-			<div className='onenote-picker ms-fontColor-themePrimary'>
-				<ul role='tree' aria-label={Strings.get('Accessibility.PickerTableName', this.props.globals.strings)}
-					className='menu-list picker-list-header' aria-activedescendent={this.activeDescendentId}>
-					{notebookRenderStrategies.map((renderStrategy, i) =>
-						!!this.props.globals.callbacks.onSectionSelected || !!this.props.globals.callbacks.onPageSelected ?
-							<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
-								treeViewId={this.treeViewId} key={renderStrategy.getId()}
-								id={renderStrategy.getId()} tabbable={i === 0} focusOnMount={focusOnMount && i === 0}
-								ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}></ExpandableNode> :
-							<LeafNode globals={this.props.globals} node={renderStrategy} treeViewId={this.treeViewId} key={renderStrategy.getId()}
-								id={renderStrategy.getId()} tabbable={i === 0} focusOnMount={focusOnMount && i === 0}
-								ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}></LeafNode>)}
-
-					{sharedNotebookRenderStrategies.map((renderStrategy, i) =>
-						!!this.props.globals.callbacks.onSectionSelected || !!this.props.globals.callbacks.onPageSelected ?
-							<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
-								treeViewId={this.treeViewId} key={renderStrategy.getId()}
-								id={renderStrategy.getId()} tabbable={noPersonalNotebooks && i === 0}
-								focusOnMount={focusOnMount && noPersonalNotebooks && i === 0}
-								ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noPersonalNotebooks && i === 0}></ExpandableNode> :
-							<LeafNode globals={this.props.globals} node={renderStrategy} treeViewId={this.treeViewId} key={renderStrategy.getId()}
-								id={renderStrategy.getId()} tabbable={noPersonalNotebooks && i === 0}
-								focusOnMount={focusOnMount && noPersonalNotebooks && i === 0}
-								ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noPersonalNotebooks && i === 0}></LeafNode>)}
-				</ul>
-			</div>
-		);
+		const notebookNodes = notebookRenderStrategies.map((renderStrategy, i) =>
+			!!this.props.globals.callbacks.onSectionSelected || !!this.props.globals.callbacks.onPageSelected ?
+				<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
+					treeViewId={this.treeViewId} key={renderStrategy.getId()}
+					id={renderStrategy.getId()} tabbable={i === 0} focusOnMount={focusOnMount && i === 0}
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}></ExpandableNode> :
+				<LeafNode globals={this.props.globals} node={renderStrategy} treeViewId={this.treeViewId} key={renderStrategy.getId()}
+					id={renderStrategy.getId()} tabbable={i === 0} focusOnMount={focusOnMount && i === 0}
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}></LeafNode>);
+		
+		const sharedNotebookNodes = sharedNotebookRenderStrategies.map((renderStrategy, i) =>
+			!!this.props.globals.callbacks.onSectionSelected || !!this.props.globals.callbacks.onPageSelected ?
+				<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
+					treeViewId={this.treeViewId} key={renderStrategy.getId()}
+					id={renderStrategy.getId()} tabbable={noPersonalNotebooks && i === 0}
+					focusOnMount={focusOnMount && noPersonalNotebooks && i === 0}
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noPersonalNotebooks && i === 0}></ExpandableNode> :
+				<LeafNode globals={this.props.globals} node={renderStrategy} treeViewId={this.treeViewId} key={renderStrategy.getId()}
+					id={renderStrategy.getId()} tabbable={noPersonalNotebooks && i === 0}
+					focusOnMount={focusOnMount && noPersonalNotebooks && i === 0}
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noPersonalNotebooks && i === 0}></LeafNode>);
+		
+		return notebookNodes.concat(sharedNotebookNodes);
 	}
 }
+
+export * from './oneNoteSingleNotebookPicker';

--- a/src/oneNotePickerBase.tsx
+++ b/src/oneNotePickerBase.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import './oneNotePicker.scss';
+
+import {Constants} from './constants';
+import {Strings} from './strings';
+import {GlobalProps} from './props/globalProps';
+
+export abstract class OneNotePickerBase<TState extends GlobalProps, TProps> extends React.Component<TState, TProps> {
+	protected get treeViewId() {
+		return Constants.TreeView.id;
+	}
+
+	protected get activeDescendentId() {
+		if (!this.props.globals.ariaSelectedId) {
+			return '';
+		}
+		return this.treeViewId + this.props.globals.ariaSelectedId;
+	}
+
+	protected abstract get rootNodes(): JSX.Element[];
+
+	render() {
+		return (
+			<div className='onenote-picker ms-fontColor-themePrimary'>
+				<ul role='tree' aria-label={Strings.get('Accessibility.PickerTableName', this.props.globals.strings)}
+					className='menu-list picker-list-header' aria-activedescendent={this.activeDescendentId}>
+					{this.rootNodes}
+				</ul>
+			</div>
+		);
+	}
+}

--- a/src/oneNoteSingleNotebookDropdown.tsx
+++ b/src/oneNoteSingleNotebookDropdown.tsx
@@ -7,7 +7,9 @@ export interface OneNoteSingleNotebookDropdownState {
 }
 
 export interface OneNoteSingleNotebookDropdownProps extends OneNoteSingleNotebookPickerProps {
-
+	dropdownLabel: string;
+	popupDirection: 'bottom' | 'top';
+	popupContentOverride?: JSX.Element;
 }
 
 export class OneNoteSingleNotebookDropdown extends React.Component<OneNoteSingleNotebookDropdownProps, OneNoteSingleNotebookDropdownState> {
@@ -53,13 +55,22 @@ export class OneNoteSingleNotebookDropdown extends React.Component<OneNoteSingle
 		newProps.globals.callbacks = newCallbacks;
 
 		return (
-			<div>
-				<div>
-					<button onClick={this.onClick.bind(this)}>Click me</button>
+			<div className='picker-dropdown'>
+				<div className='picker-dropdown-padding'>
+					<a className='picker-dropdown-toggle' onClick={this.onClick.bind(this)}>
+						<div className='dropdown-arrow-container'>
+							<svg version='1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'>
+								<polygon id='XMLID_10_' points='3.5,7 4.4,6.1 8,9.7 11.7,6.1 12.6,7 8,11.5'/>
+							</svg>
+						</div>
+						<div className='picker-dropdown-toggle-label' title={this.props.dropdownLabel}>
+							{this.props.dropdownLabel}
+						</div>
+					</a>
 				</div>
 				{this.state.popupVisible ?
-					<div>
-						<OneNoteSingleNotebookPicker {...newProps} />
+					<div className={'picker-popup ' + (this.props.popupDirection === 'top' ? 'popup-upwards' : '')}>
+						{this.props.popupContentOverride ? this.props.popupContentOverride : <OneNoteSingleNotebookPicker {...newProps} />}
 					</div> :
 					undefined}
 			</div>

--- a/src/oneNoteSingleNotebookDropdown.tsx
+++ b/src/oneNoteSingleNotebookDropdown.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+import {OneNoteSingleNotebookPickerProps, OneNoteSingleNotebookPicker} from './oneNoteSingleNotebookPicker';
+
+export interface OneNoteSingleNotebookDropdownState {
+	popupVisible: boolean;
+}
+
+export interface OneNoteSingleNotebookDropdownProps extends OneNoteSingleNotebookPickerProps {
+
+}
+
+export class OneNoteSingleNotebookDropdown extends React.Component<OneNoteSingleNotebookDropdownProps, OneNoteSingleNotebookDropdownState> {
+	constructor() {
+		super();
+		this.state = {
+			popupVisible: false
+		};
+	}
+
+	onClick() {
+		this.setState({
+			popupVisible: !this.state.popupVisible
+		});
+	}
+
+	onPickerItemClicked() {
+		this.setState({
+			popupVisible: false
+		});
+	}
+
+	render() {
+		let newCallbacks = { ...this.props.globals.callbacks };
+		
+		if (newCallbacks.onSectionSelected) {
+			let decorated = newCallbacks.onSectionSelected;
+			newCallbacks.onSectionSelected = (section, breadcrumbs) => {
+				this.onPickerItemClicked();
+				decorated(section, breadcrumbs);
+			};
+		}
+
+		if (newCallbacks.onPageSelected) {
+			let decorated = newCallbacks.onPageSelected;
+			newCallbacks.onPageSelected = (page, breadcrumbs) => {
+				this.onPickerItemClicked();
+				decorated(page, breadcrumbs);
+			};
+		}
+
+		let newProps = { ...this.props };
+		newProps.globals.callbacks = newCallbacks;
+
+		return (
+			<div>
+				<div>
+					<button onClick={this.onClick.bind(this)}>Click me</button>
+				</div>
+				{this.state.popupVisible ?
+					<div>
+						<OneNoteSingleNotebookPicker {...newProps} />
+					</div> :
+					undefined}
+			</div>
+		);
+	}
+}

--- a/src/oneNoteSingleNotebookPicker.tsx
+++ b/src/oneNoteSingleNotebookPicker.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import './oneNotePicker.scss';
+
+import {OneNotePickerBase} from './oneNotePickerBase';
+import {SectionGroupRenderStrategy} from './components/sectionGroupRenderStrategy';
+import {SectionRenderStrategy} from './components/sectionRenderStrategy';
+import {ExpandableNode} from './components/treeView/expandableNode';
+import {LeafNode} from './components/treeView/leafNode';
+import {ExpandableNodeRenderStrategy} from './components/treeView/expandableNodeRenderStrategy';
+import {GlobalProps} from './props/globalProps';
+import {SectionGroup} from './oneNoteDataStructures/sectionGroup';
+import {Section} from './oneNoteDataStructures/section';
+
+export interface OneNoteSingleNotebookPickerProps extends GlobalProps {
+	sectionGroups: SectionGroup[];
+	sections: Section[];
+}
+
+export class OneNoteSingleNotebookPicker extends OneNotePickerBase<OneNoteSingleNotebookPickerProps, {}> {
+	protected get rootNodes(): JSX.Element[] {
+		const { sectionGroups, sections, globals } = this.props;
+		const { focusOnMount, ariaSelectedId } = globals;
+
+		const sectionGroupRenderStrategies: ExpandableNodeRenderStrategy[] =
+			sectionGroups.map(sectionGroup => new SectionGroupRenderStrategy(sectionGroup, globals));
+		
+		const sectionRenderStrategies: ExpandableNodeRenderStrategy[] =
+			sections.map(section => new SectionRenderStrategy(section, globals));
+
+		const noSectionGroups = sectionGroups.length === 0;
+
+		const sectionGroupNodes = sectionGroupRenderStrategies.map((renderStrategy, i) =>
+			<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
+				treeViewId={this.treeViewId} key={renderStrategy.getId()}
+				id={renderStrategy.getId()} tabbable={i === 0} focusOnMount={focusOnMount && i === 0}
+				ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}></ExpandableNode>);
+		
+		const sectionNodes = sectionRenderStrategies.map((renderStrategy, i) =>
+			!!this.props.globals.callbacks.onPageSelected ?
+				<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
+					treeViewId={this.treeViewId} key={renderStrategy.getId()}
+					id={renderStrategy.getId()} tabbable={noSectionGroups && i === 0}
+					focusOnMount={focusOnMount && noSectionGroups && i === 0}
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noSectionGroups && i === 0}></ExpandableNode> :
+				<LeafNode globals={this.props.globals} node={renderStrategy} treeViewId={this.treeViewId} key={renderStrategy.getId()}
+					id={renderStrategy.getId()} tabbable={noSectionGroups && i === 0}
+					focusOnMount={focusOnMount && noSectionGroups && i === 0}
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noSectionGroups && i === 0}></LeafNode>);
+		
+		return sectionGroupNodes.concat(sectionNodes);
+	}
+}

--- a/src/oneNoteSingleNotebookPicker.tsx
+++ b/src/oneNoteSingleNotebookPicker.tsx
@@ -48,6 +48,6 @@ export class OneNoteSingleNotebookPicker extends OneNotePickerBase<OneNoteSingle
 					focusOnMount={focusOnMount && noSectionGroups && i === 0}
 					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noSectionGroups && i === 0}></LeafNode>);
 		
-		return sectionGroupNodes.concat(sectionNodes);
+		return sectionNodes.concat(sectionGroupNodes);
 	}
 }

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -8,7 +8,7 @@ export class Strings {
 		'Accessibility.SectionGroupIcon': 'Section Group Icon',
 		'Accessibility.SectionIcon': 'Section Icon',
 		'Accessibility.PickerTableName': 'Save Locations',
-		'Accessibility.PageIcon': 'Page Icon',
+		'Accessibility.PageIcon': 'Page Icon'
 	};
 
 	static get(key: string, overrides?: {}) {


### PR DESCRIPTION
- Devs can now choose to use a popup version of the picker
- Icons are now svg and i, making it easier to override their styles
- Allow SGs and sections at the root level
- Minor bug fixes

TODO:
- Cleanup of the new styles, and making it easier for devs to override them (e.g., via props, instead of using css overrides).