### PR TITLE
Add top and bottom padding to the menu. Fix expand logic

### DIFF
--- a/src/components/notebookRenderStrategy.tsx
+++ b/src/components/notebookRenderStrategy.tsx
@@ -77,6 +77,9 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 		if (!!onNotebookSelected) {
 			onNotebookSelected(this.notebook, OneNoteItemUtils.getAncestry(this.notebook));
 		}
-		this.notebook.expanded = !this.notebook.expanded;
+
+		if (this.globals.callbacks.onSectionSelected || this.globals.callbacks.onPageSelected) {
+			this.notebook.expanded = !this.notebook.expanded;
+		}	
 	}
 }

--- a/src/components/pageRenderStrategy.tsx
+++ b/src/components/pageRenderStrategy.tsx
@@ -15,7 +15,7 @@ export class PageRenderStrategy implements NodeRenderStrategy {
 		// TODO image is a placeholder as we don't support pages yet
 		return (
 			<div className={this.isSelected() ? 'picker-selectedItem' : ''} title={this.page.name}>
-				<div className='picker-icon-left'>
+				<div className='picker-icon'>
 					<img
 						src={require('../images/section_icon.png')}
 						alt={Strings.get('Accessibility.PageIcon', this.globals.strings)}/>

--- a/src/components/sharedNotebookRenderStrategy.tsx
+++ b/src/components/sharedNotebookRenderStrategy.tsx
@@ -105,7 +105,9 @@ export class SharedNotebookRenderStrategy implements ExpandableNodeRenderStrateg
 			onNotebookSelected(this.notebook, OneNoteItemUtils.getAncestry(this.notebook));
 		}
 
-		this.notebook.expanded = !this.notebook.expanded;
+		if (this.globals.callbacks.onSectionSelected || this.globals.callbacks.onPageSelected) {
+			this.notebook.expanded = !this.notebook.expanded;
+		}
 	}
 
 	private onExpand() {

--- a/src/oneNotePicker.scss
+++ b/src/oneNotePicker.scss
@@ -92,15 +92,20 @@ svg.spinner {
 		}
 	}
 
-	.menu-list a {
-		color: #4a4a4a;
-		display: block;
-	}
+	.menu-list {
+		margin-top: 0;
+		margin-bottom: 10px;
 
-	.menu-list li ul {
-		margin: 0;
-		border-left: none;
-		padding-left: 1.5rem;
+		a {
+			color: #4a4a4a;
+			display: block;
+		}
+
+		li ul {
+			margin: 0;
+			border-left: none;
+			padding-left: 1.5rem;
+		}
 	}
 
 	.picker-selectedItem {

--- a/src/oneNoteSingleNotebookDropdown.tsx
+++ b/src/oneNoteSingleNotebookDropdown.tsx
@@ -13,11 +13,16 @@ export interface OneNoteSingleNotebookDropdownProps extends OneNoteSingleNoteboo
 }
 
 export class OneNoteSingleNotebookDropdown extends React.Component<OneNoteSingleNotebookDropdownProps, OneNoteSingleNotebookDropdownState> {
+	private wrapperRef: Node;
+
 	constructor() {
 		super();
 		this.state = {
 			popupVisible: false
 		};
+
+		this.setWrapperRef = this.setWrapperRef.bind(this);
+		this.handleClickOutside = this.handleClickOutside.bind(this);
 	}
 
 	onClick() {
@@ -30,6 +35,26 @@ export class OneNoteSingleNotebookDropdown extends React.Component<OneNoteSingle
 		this.setState({
 			popupVisible: false
 		});
+	}
+
+	private setWrapperRef(node) {
+		this.wrapperRef = node as Node;
+	}
+
+	private handleClickOutside(event) {
+		if (this.wrapperRef && !this.wrapperRef.contains(event.target) && this.state.popupVisible) {
+			this.setState({
+				popupVisible: false
+			});
+		}
+	}
+
+	componentDidMount() {
+		document.addEventListener('mousedown', this.handleClickOutside);
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener('mousedown', this.handleClickOutside);
 	}
 
 	render() {
@@ -55,7 +80,7 @@ export class OneNoteSingleNotebookDropdown extends React.Component<OneNoteSingle
 		newProps.globals.callbacks = newCallbacks;
 
 		return (
-			<div className='picker-dropdown'>
+			<div className='picker-dropdown' ref={this.setWrapperRef}>
 				<div className='picker-dropdown-padding'>
 					<a className='picker-dropdown-toggle' onClick={this.onClick.bind(this)}>
 						<div className='dropdown-arrow-container'>


### PR DESCRIPTION
- Add top-bottom padding to menu that originally came from bootstrap
- Fix expand logic (we should only expand a notebook if we regard it as expandable)
- If the user clicks outside the dropdown, close