### PR TITLE
First iteration of allowing create notebook and section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "2.3.5",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8561,9 +8561,9 @@
       "dev": true
     },
     "onenoteapi": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/onenoteapi/-/onenoteapi-2.0.5.tgz",
-      "integrity": "sha512-LMnF2voVUU9lMUoiJD/gwBh5xVLlvkKkBIXEGgy7oxwfNSo+jVsxN/R5DRU1noFizbKWh5uWni31ZGxH88C8Kg=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/onenoteapi/-/onenoteapi-2.0.6.tgz",
+      "integrity": "sha512-4ynGrPImj3RuAS2S/ypZVam2yOQjxiN5/ABD81Ru5LGj6EQQw37wjMzBkxw2qqEiorPrN0FX92onySIVaaMMdA=="
     },
     "onetime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "onenotepicker",
-  "version": "2.3.5",
+  "version": "2.4.0",
   "files": [
     "dist/**/*"
   ],
   "dependencies": {
     "bulma": "^0.4.2",
-    "onenoteapi": "2.0.5",
+    "onenoteapi": "2.0.6",
     "react": "^15.6.2",
     "react-dom": "^15.6.2"
   },

--- a/sampleApp/sample.tsx
+++ b/sampleApp/sample.tsx
@@ -5,6 +5,7 @@ import { OneNotePicker } from '../src/oneNotePicker';
 import { GlobalProps } from '../src/props/globalProps';
 import { OneNoteDataProvider } from '../src/providers/oneNoteDataProvider';
 import { Notebook } from '../src/oneNoteDataStructures/notebook';
+import { Section } from '../src/oneNoteDataStructures/section';
 import { OneNoteItemUtils } from '../src/oneNoteDataStructures/oneNoteItemUtils';
 import { NotebookListUpdater } from '../src/oneNoteDataStructures/notebookListUpdater';
 import { SampleOneNoteDataProvider } from './sampleOneNoteDataProvider';
@@ -55,6 +56,32 @@ oneNoteDataProvider.getNotebooks().then((notebooks) => {
 				},
 				onAccessibleSelection: (selectedItemId: string) => {
 					globalProps.globals.ariaSelectedId = selectedItemId;
+
+					render(globalProps, globalProps.globals.notebookListUpdater!.get());
+				},
+				onNotebookCreated: (notebook: Notebook) => {
+					// Allow max one creation
+					globalProps.globals.callbacks.onNotebookCreated = undefined;
+
+					if (globalProps.globals.notebookListUpdater) {
+						globalProps.globals.notebookListUpdater.addNotebook(notebook);
+						globalProps.globals.selectedId = notebook.id;
+					}
+
+					// tslint:disable-next-line:no-console
+					console.log(`Notebook created: ${notebook.name}`);
+
+					render(globalProps, globalProps.globals.notebookListUpdater!.get());
+				},
+				onSectionCreated: (section: Section) => {
+					// TODO (machiam) Introduce a way of only allowing max one section creation per parent
+					// tslint:disable-next-line:no-console
+					console.log(`Section created: ${section.name}`);
+
+					if (globalProps.globals.notebookListUpdater) {
+						globalProps.globals.notebookListUpdater!.addSection(section);
+						globalProps.globals.selectedId = section.id;
+					}
 
 					render(globalProps, globalProps.globals.notebookListUpdater!.get());
 				}

--- a/sampleApp/sampleOneNoteDataProvider.ts
+++ b/sampleApp/sampleOneNoteDataProvider.ts
@@ -3,6 +3,7 @@ import * as OneNoteApi from '../node_modules/onenoteapi/target/oneNoteApi';
 
 import { OneNoteDataProvider } from '../src/providers/oneNoteDataProvider';
 import { Notebook } from '../src/oneNoteDataStructures/notebook';
+import { SectionGroup } from '../src/oneNoteDataStructures/sectionGroup';
 import { Section } from '../src/oneNoteDataStructures/section';
 import { SharedNotebookApiProperties } from '../src/oneNoteDataStructures/sharedNotebook';
 import { Page } from '../src/oneNoteDataStructures/page';
@@ -194,6 +195,41 @@ const mockResponse: OneNoteApi.ResponsePackage<any> = {
 };
 
 export class SampleOneNoteDataProvider implements OneNoteDataProvider {
+	createNotebook(name: string): Promise<Notebook> {
+		const notebook: Notebook = {
+			expanded: false,
+			sectionGroups: [],
+			sections: [],
+			webUrl: '',
+			apiUrl: '',
+			parent: undefined,
+			id: '' + Math.random(),
+			name: name
+		};
+		return Promise.resolve(notebook);
+	}
+
+	createSectionUnderNotebook(parent: Notebook, name: string): Promise<Section> {
+		return Promise.resolve(this.createSection(parent, name));
+	}
+
+	createSectionUnderSectionGroup(parent: SectionGroup, name: string): Promise<Section> {
+		return Promise.resolve(this.createSection(parent, name));
+	}
+
+	private createSection(parent: Notebook | SectionGroup, name: string): Section {
+		return {
+			expanded: false,
+			pages: undefined,
+			apiUrl: '',
+			webUrl: '',
+			clientUrl: '',
+			parent: parent,
+			id: '' + Math.random(),
+			name: name
+		};
+	}
+
 	getNotebooks(expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<Notebook[]> {
 		const responseTransformer = new OneNoteApiResponseTransformer();
 		const notebooks = responseTransformer.transformNotebooks(mockResponse.parsedResponse.value);

--- a/src/components/createNewNotebook/createNewNotebookCommonProperties.ts
+++ b/src/components/createNewNotebook/createNewNotebookCommonProperties.ts
@@ -1,0 +1,20 @@
+import { Strings } from '../../strings';
+import { Constants } from '../../constants';
+
+export class CreateNewNotebookCommonProperties {
+	getId(): string {
+		return Constants.TreeView.createNewNotebookId;
+	}
+
+	getName(): string {
+		return Strings.get('Label.CreateNotebook');
+	}
+
+	isSelected(): boolean {
+		return false;
+	}
+
+	isAriaSelected(): boolean {
+		return false;
+	}
+}

--- a/src/components/createNewNotebook/createNewNotebookCreateErrorRenderStrategy.tsx
+++ b/src/components/createNewNotebook/createNewNotebookCreateErrorRenderStrategy.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
+import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
+import { Strings } from '../../strings';
+import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
+import { CreateNewNotebookRowTemplate } from './createNewNotebookRowTemplate';
+
+export class CreateNewNotebookCreateErrorRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
+	onClickBinded = () => { };
+
+	// We don't listen for enter as we assume that we want the user to change the name before
+	// re-attempting the create
+	constructor(
+		private notebookNameInputValue: string,
+		private onChangeBinded: (event: React.ChangeEvent<HTMLInputElement>) => void) {
+		super();
+	}
+
+	element(): JSX.Element {
+		// TODO (machiam) error info should have a popover as per redlines
+		return (
+			<CreateNewNotebookRowTemplate>
+				<div className='picker-label'>
+					<input
+						className='create-input'
+						type='text'
+						placeholder={Strings.get('Input.CreateNotebookPlaceholder')}
+						autoComplete='off'
+						value={this.notebookNameInputValue}
+						onChange={this.onChangeBinded} />
+				</div>
+				<div className='error-info-icon'>
+					<ErrorInfoIconSvg />
+				</div>
+			</CreateNewNotebookRowTemplate>
+		);
+	}
+}

--- a/src/components/createNewNotebook/createNewNotebookErrorRenderStrategy.tsx
+++ b/src/components/createNewNotebook/createNewNotebookErrorRenderStrategy.tsx
@@ -3,38 +3,37 @@ import * as React from 'react';
 import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
 import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
 import { Strings } from '../../strings';
-import { CreateNewSectionCommonProperties } from './createNewSectionCommonProperties';
-import { CreateNewSectionRowTemplate } from './createNewSectionRowTemplate';
+import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
+import { CreateNewNotebookRowTemplate } from './createNewNotebookRowTemplate';
 
-export class CreateNewSectionCreateErrorRenderStrategy extends CreateNewSectionCommonProperties implements NodeRenderStrategy {
+export class CreateNewNotebookErrorRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
 	onClickBinded = () => { };
 
 	// We don't listen for enter as we assume that we want the user to change the name before
 	// re-attempting the create
 	constructor(
-		parentId: string,
-		private sectionNameInputValue: string,
+		private notebookNameInputValue: string,
 		private onChangeBinded: (event: React.ChangeEvent<HTMLInputElement>) => void) {
-		super(parentId);
+		super();
 	}
 
 	element(): JSX.Element {
 		// TODO (machiam) error info should have a popover as per redlines
 		return (
-			<CreateNewSectionRowTemplate>
+			<CreateNewNotebookRowTemplate>
 				<div className='picker-label'>
 					<input
 						className='create-input'
 						type='text'
-						placeholder={Strings.get('Input.CreateSectionPlaceholder')}
+						placeholder={Strings.get('Input.CreateNotebookPlaceholder')}
 						autoComplete='off'
-						value={this.sectionNameInputValue}
+						value={this.notebookNameInputValue}
 						onChange={this.onChangeBinded} />
 				</div>
 				<div className='error-info-icon'>
 					<ErrorInfoIconSvg />
 				</div>
-			</CreateNewSectionRowTemplate>
+			</CreateNewNotebookRowTemplate>
 		);
 	}
 }

--- a/src/components/createNewNotebook/createNewNotebookInProgressRenderStrategy.tsx
+++ b/src/components/createNewNotebook/createNewNotebookInProgressRenderStrategy.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
+import { SpinnerIconSvg } from '../icons/spinnerIcon.svg';
+import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
+import { CreateNewNotebookRowTemplate } from './createNewNotebookRowTemplate';
+
+export class CreateNewNotebookInProgressRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
+	onClickBinded = () => { };
+
+	constructor(private name: string) {
+		super();
+	}
+
+	element(): JSX.Element {
+		return (
+			<CreateNewNotebookRowTemplate>
+				<div className='picker-label'>
+					<label>{this.name}</label>
+					<div className='create-spinner'>
+						<SpinnerIconSvg />
+					</div>
+				</div>
+			</CreateNewNotebookRowTemplate>
+		);
+	}
+}

--- a/src/components/createNewNotebook/createNewNotebookInputRenderStrategy.tsx
+++ b/src/components/createNewNotebook/createNewNotebookInputRenderStrategy.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
+import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
+import { Strings } from '../../strings';
+import { NameValidator } from '../../nameValidator';
+import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
+import { CreateNewNotebookRowTemplate } from './createNewNotebookRowTemplate';
+
+export class CreateNewNotebookInputRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
+	onClickBinded = () => { };
+
+	constructor(
+		private notebookNameInputValue: string,
+		private onEnterBinded: (event) => void,
+		private onChangeBinded: (event: React.ChangeEvent<HTMLInputElement>) => void,
+		private inputRefBinded: (node: HTMLInputElement) => void) {
+		super();
+	}
+
+	element(): JSX.Element {
+		// TODO (machiam) error info should have a popover as per redlines
+		return (
+			<CreateNewNotebookRowTemplate>
+				<div className='picker-label'>
+					<input
+						className='create-input'
+						ref={this.inputRefBinded}
+						type='text'
+						name='notebookName'
+						placeholder={Strings.get('Input.CreateNotebookPlaceholder')}
+						autoComplete='off'
+						value={this.notebookNameInputValue}
+						onKeyPress={this.onKeyPress.bind(this)}
+						onChange={this.onChangeBinded} />
+				</div>
+				<div className='error-info-icon' style={this.showError() ? { } : { visibility: 'hidden' }}>
+					<ErrorInfoIconSvg />
+				</div>
+			</CreateNewNotebookRowTemplate>
+		);
+	}
+
+	private showError(): boolean {
+		return !!NameValidator.validateNotebookName(this.notebookNameInputValue);
+	}
+
+	private onKeyPress(event): void {
+		if (event.key === 'Enter') {
+			this.onEnterBinded(event);
+		}
+	}
+}

--- a/src/components/createNewNotebook/createNewNotebookNode.tsx
+++ b/src/components/createNewNotebook/createNewNotebookNode.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
+import { CreateNewNotebookNotStartedRenderStrategy } from './createNewNotebookNotStartedRenderStrategy';
+import { CreateNewNotebookInputRenderStrategy } from './createNewNotebookInputRenderStrategy';
+import { CreateNewNotebookInProgressRenderStrategy } from './createNewNotebookInProgressRenderStrategy';
+import { CreateNewNotebookCreateErrorRenderStrategy } from './createNewNotebookCreateErrorRenderStrategy';
+import { InnerGlobals } from '../../props/globalProps';
+import { CreateEntityNode } from '../treeView/createEntityNode';
+
+export interface CreateNewNotebookNodeProps extends InnerGlobals {
+	level: number;
+	tabbable: boolean;
+}
+
+/**
+ * Presentation component that extends the 'Create' UX with notebook-specific
+ * UI.
+ */
+export class CreateNewNotebookNode extends React.Component<CreateNewNotebookNodeProps, {}> {
+	constructor() {
+		super();
+
+		this.notStartedRenderStrategy = this.notStartedRenderStrategy.bind(this);
+		this.inputRenderStrategy = this.inputRenderStrategy.bind(this);
+		this.createErrorRenderStrategy = this.createErrorRenderStrategy.bind(this);
+		this.inProgressRenderStrategy = this.inProgressRenderStrategy.bind(this);
+		this.createNotebook = this.createNotebook.bind(this);
+	}
+
+	private notStartedRenderStrategy(onClick: () => void): NodeRenderStrategy {
+		return new CreateNewNotebookNotStartedRenderStrategy(onClick);
+	}
+
+	private inputRenderStrategy(
+		inputValue: string,
+		onEnter: () => void,
+		onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void,
+		setInputRefAndFocus: (node: HTMLInputElement) => void): NodeRenderStrategy {
+		return new CreateNewNotebookInputRenderStrategy(inputValue, onEnter, onInputChange, setInputRefAndFocus);
+	}
+
+	private createErrorRenderStrategy(inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void): NodeRenderStrategy {
+		return new CreateNewNotebookCreateErrorRenderStrategy(inputValue, onInputChange);
+	}
+
+	private inProgressRenderStrategy(inputValue: string): NodeRenderStrategy {
+		return new CreateNewNotebookInProgressRenderStrategy(inputValue);
+	}
+
+	private createNotebook(name: string): Promise<void> {
+		return this.props.oneNoteDataProvider!.createNotebook(name).then((notebook) => {
+			return this.props.callbacks.onNotebookCreated!(notebook);
+		});
+	}
+
+	render() {
+		return (
+			<CreateEntityNode
+				{...this.props}
+				notStartedRenderStrategy={this.notStartedRenderStrategy}
+				inputRenderStrategy={this.inputRenderStrategy}
+				createErrorRenderStrategy={this.createErrorRenderStrategy}
+				inProgressRenderStrategy={this.inProgressRenderStrategy}
+				createEntity={this.createNotebook}>
+			</CreateEntityNode>
+		);
+	}
+}

--- a/src/components/createNewNotebook/createNewNotebookNode.tsx
+++ b/src/components/createNewNotebook/createNewNotebookNode.tsx
@@ -4,7 +4,7 @@ import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
 import { CreateNewNotebookNotStartedRenderStrategy } from './createNewNotebookNotStartedRenderStrategy';
 import { CreateNewNotebookInputRenderStrategy } from './createNewNotebookInputRenderStrategy';
 import { CreateNewNotebookInProgressRenderStrategy } from './createNewNotebookInProgressRenderStrategy';
-import { CreateNewNotebookCreateErrorRenderStrategy } from './createNewNotebookCreateErrorRenderStrategy';
+import { CreateNewNotebookErrorRenderStrategy } from './createNewNotebookErrorRenderStrategy';
 import { InnerGlobals } from '../../props/globalProps';
 import { CreateEntityNode } from '../treeView/createEntityNode';
 
@@ -41,7 +41,7 @@ export class CreateNewNotebookNode extends React.Component<CreateNewNotebookNode
 	}
 
 	private createErrorRenderStrategy(inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void): NodeRenderStrategy {
-		return new CreateNewNotebookCreateErrorRenderStrategy(inputValue, onInputChange);
+		return new CreateNewNotebookErrorRenderStrategy(inputValue, onInputChange);
 	}
 
 	private inProgressRenderStrategy(inputValue: string): NodeRenderStrategy {

--- a/src/components/createNewNotebook/createNewNotebookNotStartedRenderStrategy.tsx
+++ b/src/components/createNewNotebook/createNewNotebookNotStartedRenderStrategy.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
+import { AddIconSvg } from '../icons/addIcon.svg';
+import { ChevronSvg } from '../icons/chevron.svg';
+import { Strings } from '../../strings';
+import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
+
+export class CreateNewNotebookNotStartedRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
+	onClickBinded = this.onClick;
+
+	constructor(private onClick: () => void) {
+		super();
+	}
+
+	element(): JSX.Element {
+		return (
+			<div className='notebook'>
+				<div className='chevron-icon closed' style={{ visibility: 'hidden' }}>
+					<ChevronSvg />
+				</div>
+				<div className='picker-icon'>
+					<AddIconSvg />
+				</div>
+				<div className='picker-label'>
+					<label className='create-label'>{Strings.get('Label.CreateNotebook')}</label>
+				</div>
+			</div>
+		);
+	}
+}

--- a/src/components/createNewNotebook/createNewNotebookRowTemplate.tsx
+++ b/src/components/createNewNotebook/createNewNotebookRowTemplate.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { ChevronSvg } from '../icons/chevron.svg';
+import { NotebookClosedIconSvg } from '../icons/notebookClosedIcon.svg';
+
+export class CreateNewNotebookRowTemplate extends React.Component<{}, {}> {
+	render() {
+		return (
+			<div className='notebook'>
+				<div className='chevron-icon closed' style={{ visibility: 'hidden' }}>
+					<ChevronSvg />
+				</div>
+				<div className='picker-icon'>
+					<NotebookClosedIconSvg />
+				</div>
+				{this.props.children}
+			</div>
+		);
+	}
+}

--- a/src/components/createNewSection/createNewSectionCommonProperties.ts
+++ b/src/components/createNewSection/createNewSectionCommonProperties.ts
@@ -1,0 +1,22 @@
+import { Strings } from '../../strings';
+import { Constants } from '../../constants';
+
+export class CreateNewSectionCommonProperties {
+	constructor(private parentId: string) { }
+
+	getId(): string {
+		return Constants.TreeView.createNewSectionIdPrefix + this.parentId;
+	}
+
+	getName(): string {
+		return Strings.get('Label.CreateSection');
+	}
+
+	isSelected(): boolean {
+		return false;
+	}
+
+	isAriaSelected(): boolean {
+		return false;
+	}
+}

--- a/src/components/createNewSection/createNewSectionCreateErrorRenderStrategy.tsx
+++ b/src/components/createNewSection/createNewSectionCreateErrorRenderStrategy.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
+import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
+import { Strings } from '../../strings';
+import { CreateNewSectionCommonProperties } from './createNewSectionCommonProperties';
+import { CreateNewSectionRowTemplate } from './createNewSectionRowTemplate';
+
+export class CreateNewSectionCreateErrorRenderStrategy extends CreateNewSectionCommonProperties implements NodeRenderStrategy {
+	onClickBinded = () => { };
+
+	// We don't listen for enter as we assume that we want the user to change the name before
+	// re-attempting the create
+	constructor(
+		parentId: string,
+		private sectionNameInputValue: string,
+		private onChangeBinded: (event: React.ChangeEvent<HTMLInputElement>) => void) {
+		super(parentId);
+	}
+
+	element(): JSX.Element {
+		// TODO (machiam) error info should have a popover as per redlines
+		return (
+			<CreateNewSectionRowTemplate>
+				<div className='picker-label'>
+					<input
+						className='create-input'
+						type='text'
+						placeholder={Strings.get('Input.CreateSectionPlaceholder')}
+						autoComplete='off'
+						value={this.sectionNameInputValue}
+						onChange={this.onChangeBinded} />
+				</div>
+				<div className='error-info-icon'>
+					<ErrorInfoIconSvg />
+				</div>
+			</CreateNewSectionRowTemplate>
+		);
+	}
+}

--- a/src/components/createNewSection/createNewSectionErrorRenderStrategy.tsx
+++ b/src/components/createNewSection/createNewSectionErrorRenderStrategy.tsx
@@ -3,37 +3,38 @@ import * as React from 'react';
 import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
 import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
 import { Strings } from '../../strings';
-import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
-import { CreateNewNotebookRowTemplate } from './createNewNotebookRowTemplate';
+import { CreateNewSectionCommonProperties } from './createNewSectionCommonProperties';
+import { CreateNewSectionRowTemplate } from './createNewSectionRowTemplate';
 
-export class CreateNewNotebookCreateErrorRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
+export class CreateNewSectionErrorRenderStrategy extends CreateNewSectionCommonProperties implements NodeRenderStrategy {
 	onClickBinded = () => { };
 
 	// We don't listen for enter as we assume that we want the user to change the name before
 	// re-attempting the create
 	constructor(
-		private notebookNameInputValue: string,
+		parentId: string,
+		private sectionNameInputValue: string,
 		private onChangeBinded: (event: React.ChangeEvent<HTMLInputElement>) => void) {
-		super();
+		super(parentId);
 	}
 
 	element(): JSX.Element {
 		// TODO (machiam) error info should have a popover as per redlines
 		return (
-			<CreateNewNotebookRowTemplate>
+			<CreateNewSectionRowTemplate>
 				<div className='picker-label'>
 					<input
 						className='create-input'
 						type='text'
-						placeholder={Strings.get('Input.CreateNotebookPlaceholder')}
+						placeholder={Strings.get('Input.CreateSectionPlaceholder')}
 						autoComplete='off'
-						value={this.notebookNameInputValue}
+						value={this.sectionNameInputValue}
 						onChange={this.onChangeBinded} />
 				</div>
 				<div className='error-info-icon'>
 					<ErrorInfoIconSvg />
 				</div>
-			</CreateNewNotebookRowTemplate>
+			</CreateNewSectionRowTemplate>
 		);
 	}
 }

--- a/src/components/createNewSection/createNewSectionInProgressRenderStrategy.tsx
+++ b/src/components/createNewSection/createNewSectionInProgressRenderStrategy.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
+import { SpinnerIconSvg } from '../icons/spinnerIcon.svg';
+import { CreateNewSectionCommonProperties } from './createNewSectionCommonProperties';
+import { CreateNewSectionRowTemplate } from './createNewSectionRowTemplate';
+
+export class CreateNewSectionInProgressRenderStrategy extends CreateNewSectionCommonProperties implements NodeRenderStrategy {
+	onClickBinded = () => { };
+
+	constructor(
+		parentId: string,
+		private name: string) {
+		super(parentId);
+	}
+
+	element(): JSX.Element {
+		return (
+			<CreateNewSectionRowTemplate>
+				<div className='picker-label'>
+					<label>{this.name}</label>
+					<div className='create-spinner'>
+						<SpinnerIconSvg />
+					</div>
+				</div>
+			</CreateNewSectionRowTemplate>
+		);
+	}
+}

--- a/src/components/createNewSection/createNewSectionInputRenderStrategy.tsx
+++ b/src/components/createNewSection/createNewSectionInputRenderStrategy.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
+import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
+import { Strings } from '../../strings';
+import { NameValidator } from '../../nameValidator';
+import { CreateNewSectionCommonProperties } from './createNewSectionCommonProperties';
+import { CreateNewSectionRowTemplate } from './createNewSectionRowTemplate';
+
+export class CreateNewSectionInputRenderStrategy extends CreateNewSectionCommonProperties implements NodeRenderStrategy {
+	onClickBinded = () => { };
+
+	constructor(
+		parentId: string,
+		private notebookNameInputValue: string,
+		private onEnterBinded: (event) => void,
+		private onChangeBinded: (event: React.ChangeEvent<HTMLInputElement>) => void,
+		private inputRefBinded: (node: HTMLInputElement) => void) {
+		super(parentId);
+	}
+
+	element(): JSX.Element {
+		// TODO (machiam) error info should have a popover as per redlines
+		return (
+			<CreateNewSectionRowTemplate>
+				<div className='picker-label'>
+					<input
+						className='create-input'
+						ref={this.inputRefBinded}
+						type='text'
+						placeholder={Strings.get('Input.CreateSectionPlaceholder')}
+						autoComplete='off'
+						value={this.notebookNameInputValue}
+						onKeyPress={this.onKeyPress.bind(this)}
+						onChange={this.onChangeBinded} />
+				</div>
+				<div className='error-info-icon' style={this.showError() ? { } : { visibility: 'hidden' }}>
+					<ErrorInfoIconSvg />
+				</div>
+			</CreateNewSectionRowTemplate>
+		);
+	}
+
+	private showError(): boolean {
+		return !!NameValidator.validateNotebookName(this.notebookNameInputValue);
+	}
+
+	private onKeyPress(event): void {
+		if (event.key === 'Enter') {
+			this.onEnterBinded(event);
+		}
+	}
+}

--- a/src/components/createNewSection/createNewSectionNode.tsx
+++ b/src/components/createNewSection/createNewSectionNode.tsx
@@ -6,7 +6,7 @@ import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
 import { CreateNewSectionNotStartedRenderStrategy } from './createNewSectionNotStartedRenderStrategy';
 import { CreateNewSectionInputRenderStrategy } from './createNewSectionInputRenderStrategy';
 import { CreateNewSectionInProgressRenderStrategy } from './createNewSectionInProgressRenderStrategy';
-import { CreateNewSectionCreateErrorRenderStrategy } from './createNewSectionCreateErrorRenderStrategy';
+import { CreateNewSectionErrorRenderStrategy } from './createNewSectionErrorRenderStrategy';
 import { InnerGlobals } from '../../props/globalProps';
 import { CreateEntityNode } from '../treeView/createEntityNode';
 
@@ -45,7 +45,7 @@ export class CreateNewSectionNode extends React.Component<CreateNewSectionNodePr
 	}
 
 	private createErrorRenderStrategy(inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void): NodeRenderStrategy {
-		return new CreateNewSectionCreateErrorRenderStrategy(this.props.parent.id, inputValue, onInputChange);
+		return new CreateNewSectionErrorRenderStrategy(this.props.parent.id, inputValue, onInputChange);
 	}
 
 	private inProgressRenderStrategy(inputValue: string): NodeRenderStrategy {

--- a/src/components/createNewSection/createNewSectionNode.tsx
+++ b/src/components/createNewSection/createNewSectionNode.tsx
@@ -53,7 +53,6 @@ export class CreateNewSectionNode extends React.Component<CreateNewSectionNodePr
 	}
 
 	private createSection(name: string): Promise<void> {
-		// TODO (machiam) We need different api calls for notebook vs sectiongroup parent
 		const createSectionPromise = this.props.parentIsNotebook ?
 			this.props.oneNoteDataProvider!.createSectionUnderNotebook(this.props.parent as Notebook, name) :
 			this.props.oneNoteDataProvider!.createSectionUnderSectionGroup(this.props.parent as SectionGroup, name);

--- a/src/components/createNewSection/createNewSectionNotStartedRenderStrategy.tsx
+++ b/src/components/createNewSection/createNewSectionNotStartedRenderStrategy.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
+import { AddIconSvg } from '../icons/addIcon.svg';
+import { Strings } from '../../strings';
+import { CreateNewSectionCommonProperties } from './createNewSectionCommonProperties';
+
+export class CreateNewSectionNotStartedRenderStrategy extends CreateNewSectionCommonProperties implements NodeRenderStrategy {
+	onClickBinded = this.onClick;
+
+	constructor(
+		parentId: string,
+		private onClick: () => void) {
+		super(parentId);
+	}
+
+	element(): JSX.Element {
+		return (
+			<div className='section'>
+				<div className='picker-icon'>
+					<AddIconSvg />
+				</div>
+				<div className='picker-label'>
+					<label className='create-label'>{Strings.get('Label.CreateSection')}</label>
+				</div>
+			</div>
+		);
+	}
+}

--- a/src/components/createNewSection/createNewSectionRowTemplate.tsx
+++ b/src/components/createNewSection/createNewSectionRowTemplate.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { SectionIconSvg } from '../icons/sectionIcon.svg';
+
+export class CreateNewSectionRowTemplate extends React.Component<{}, {}> {
+	render() {
+		return (
+			<div className='section'>
+				<div className='picker-icon'>
+					<SectionIconSvg />
+				</div>
+				{this.props.children}
+			</div>
+		);
+	}
+}

--- a/src/components/icons/addIcon.svg.tsx
+++ b/src/components/icons/addIcon.svg.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export class AddIconSvg extends React.Component {
+	render() {
+		return (
+			<svg width='15' height='15' viewBox='0 0 15 15' xmlns='http://www.w3.org/2000/svg'>
+				<g id='Icon-/-Add' fill='none' fillRule='evenodd'>
+					<path d='M8,7 L14.5,7 C14.7761424,7 15,7.22385763 15,7.5 C15,7.77614237 14.7761424,8 14.5,8 L8,8 L8,14.5 C8,14.7761424 7.77614237,15 7.5,15 C7.22385763,15 7,14.7761424 7,14.5 L7,8 L0.5,8 C0.223857625,8 0,7.77614237 0,7.5 C0,7.22385763 0.223857625,7 0.5,7 L7,7 L7,0.5 C7,0.223857625 7.22385763,5.07265313e-17 7.5,0 C7.77614237,-5.07265313e-17 8,0.223857625 8,0.5 L8,7 Z'
+					id='Combined-Shape' fill='#595858' />
+				</g>
+			</svg>
+		);
+	}
+}

--- a/src/components/icons/errorInfoIcon.svg.tsx
+++ b/src/components/icons/errorInfoIcon.svg.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+export class ErrorInfoIconSvg extends React.Component {
+	render() {
+		return (
+			<svg width='13' height='13' viewBox='0 0 13 13' xmlns='http://www.w3.org/2000/svg'>
+				<g id='info' fill='none' fillRule='evenodd'>
+					<rect id='Rectangle' fill='#C4314B' x='6' y='3' width='1' height='1' />
+					<rect id='Rectangle-2' fill='#C4314B' x='6' y='5' width='1' height='5' />
+					<circle id='Oval' stroke='#C4314B' cx='6.5' cy='6.5' r='6' />
+				</g>
+			</svg>
+		);
+	}
+}

--- a/src/components/icons/sectionIcon.svg.tsx
+++ b/src/components/icons/sectionIcon.svg.tsx
@@ -4,7 +4,7 @@ export class SectionIconSvg extends React.Component {
 	render() {
 		return (
 			<svg className='section-icon' version='1.1' xmlns='http://www.w3.org/2000/svg'
-				 xmlnsXlink='http://www.w3.org/1999/xlink' viewBox='0 0 20 20' fill='currentColor'>
+				xmlnsXlink='http://www.w3.org/1999/xlink' viewBox='0 0 20 20' fill='currentColor'>
 				<path d='M12,3H6v14h6v2h1V1h-1V3z'/>
 			</svg>
 		);

--- a/src/components/notebookRenderStrategy.tsx
+++ b/src/components/notebookRenderStrategy.tsx
@@ -11,6 +11,7 @@ import { InnerGlobals } from '../props/globalProps';
 import { NotebookOpenedIconSvg } from './icons/notebookOpenedIcon.svg';
 import { NotebookClosedIconSvg } from './icons/notebookClosedIcon.svg';
 import { ChevronSvg } from './icons/chevron.svg';
+import { CreateNewSectionNode } from './createNewSection/createNewSectionNode';
 
 export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 	onClickBinded = this.onClick.bind(this);
@@ -41,6 +42,20 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 	}
 
 	getChildren(childrenLevel: number): JSX.Element[] {
+		const createNewSection = this.globals.callbacks.onSectionCreated ?
+			[<CreateNewSectionNode
+				key={this.notebook.id + 'createnewsectionnode'}
+				{...this.globals}
+				parent={this.notebook}
+				parentIsNotebook={true}
+				level={childrenLevel}
+				// TODO (machiam) focusOnMount and tabbable logic will need to be reworked in the single notebook picker,
+				// for now we assume this is not top-level
+				focusOnMount={false}
+				tabbable={false}>
+			</CreateNewSectionNode>] :
+			[];
+
 		const sectionGroupRenderStrategies = this.notebook.sectionGroups.map(sectionGroup => new SectionGroupRenderStrategy(sectionGroup, this.globals));
 		const sectionGroups = sectionGroupRenderStrategies.map(renderStrategy =>
 			!!this.globals.callbacks.onSectionSelected || !!this.globals.callbacks.onPageSelected ?
@@ -61,7 +76,7 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 				<LeafNode node={renderStrategy} treeViewId={Constants.TreeView.id} key={renderStrategy.getId()} globals={this.globals}
 					id={renderStrategy.getId()} level={childrenLevel} ariaSelected={renderStrategy.isAriaSelected()} />);
 
-		return sections.concat(sectionGroups);
+		return [...createNewSection, ...sections, ...sectionGroups];
 	}
 
 	isExpanded(): boolean {

--- a/src/components/pageRenderStrategy.tsx
+++ b/src/components/pageRenderStrategy.tsx
@@ -18,7 +18,7 @@ export class PageRenderStrategy implements NodeRenderStrategy {
 				<div className='picker-icon'>
 					<img
 						src={require('../images/section_icon.png')}
-						alt={Strings.get('Accessibility.PageIcon', this.globals.strings)} />
+						alt={Strings.get('Accessibility.PageIcon')} />
 				</div>
 				<div>
 					<label className='ms-fontSize-sPlus'>{this.page.name}</label>

--- a/src/components/sectionGroupRenderStrategy.tsx
+++ b/src/components/sectionGroupRenderStrategy.tsx
@@ -9,6 +9,7 @@ import { SectionGroup } from '../oneNoteDataStructures/sectionGroup';
 import { InnerGlobals } from '../props/globalProps';
 import { SectionGroupIconSvg } from './icons/sectionGroupIcon.svg';
 import { ChevronSvg } from './icons/chevron.svg';
+import { CreateNewSectionNode } from './createNewSection/createNewSectionNode';
 
 export class SectionGroupRenderStrategy implements ExpandableNodeRenderStrategy {
 	onClickBinded = this.onClick.bind(this);
@@ -39,6 +40,18 @@ export class SectionGroupRenderStrategy implements ExpandableNodeRenderStrategy 
 	}
 
 	getChildren(childrenLevel: number): JSX.Element[] {
+		const createNewSection = this.globals.callbacks.onSectionCreated ?
+			[<CreateNewSectionNode
+				key={this.sectionGroup.id + 'createnewsectionnode'}
+				{...this.globals}
+				parent={this.sectionGroup}
+				parentIsNotebook={false}
+				level={childrenLevel}
+				focusOnMount={false}
+				tabbable={false}>
+			</CreateNewSectionNode>] :
+			[];
+
 		const sectionGroupRenderStrategies = this.sectionGroup.sectionGroups.map(sectionGroup => new SectionGroupRenderStrategy(sectionGroup, this.globals));
 		const sectionGroups = sectionGroupRenderStrategies.map(renderStrategy =>
 			!!this.globals.callbacks.onSectionSelected || !!this.globals.callbacks.onPageSelected ?
@@ -58,7 +71,7 @@ export class SectionGroupRenderStrategy implements ExpandableNodeRenderStrategy 
 				<LeafNode node={renderStrategy} treeViewId={Constants.TreeView.id} key={renderStrategy.getId()} globals={this.globals}
 					id={renderStrategy.getId()} level={childrenLevel} ariaSelected={renderStrategy.isAriaSelected()} />);
 
-		return sections.concat(sectionGroups);
+		return [...createNewSection, ...sections, ...sectionGroups];
 	}
 
 	isExpanded(): boolean {

--- a/src/components/sharedNotebookRenderStrategy.tsx
+++ b/src/components/sharedNotebookRenderStrategy.tsx
@@ -87,7 +87,7 @@ export class SharedNotebookRenderStrategy implements ExpandableNodeRenderStrateg
 				<LeafNode node={renderStrategy} treeViewId={Constants.TreeView.id} key={renderStrategy.getId()} globals={this.globals}
 					id={renderStrategy.getId()} level={childrenLevel} ariaSelected={renderStrategy.isAriaSelected()} />);
 
-		return sectionGroups.concat(sections);
+		return [...sectionGroups, ...sections];
 	}
 
 	isExpanded(): boolean {

--- a/src/components/sharedNotebookRenderStrategy.tsx
+++ b/src/components/sharedNotebookRenderStrategy.tsx
@@ -35,7 +35,7 @@ export class SharedNotebookRenderStrategy implements ExpandableNodeRenderStrateg
 					<label className='breadcrumbs'>{this.breadcrumbs()}</label>
 				</div>
 				<div className='picker-shared-icon'>
-					<span aria-hidden='true'>{Strings.get('Shared', this.globals.strings)}</span>
+					<span aria-hidden='true'>{Strings.get('Shared')}</span>
 					<i className='ms-Icon ms-Icon--People' />
 				</div>
 			</div>);
@@ -51,7 +51,7 @@ export class SharedNotebookRenderStrategy implements ExpandableNodeRenderStrateg
 
 	getChildren(childrenLevel: number): JSX.Element[] {
 		if (typeof (this.notebook.apiHttpErrorCode) === 'number') {
-			const errorString = Strings.getError(this.notebook.apiHttpErrorCode, this.globals.strings);
+			const errorString = Strings.getError(this.notebook.apiHttpErrorCode);
 			return [
 				<li role='status' aria-live='polite' aria-label={errorString} className='progress-row'>
 					<div>{errorString}</div>

--- a/src/components/treeView/createEntityNode.tsx
+++ b/src/components/treeView/createEntityNode.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+
+import { NodeRenderStrategy } from './nodeRenderStrategy';
+import { LeafNode, LeafNodeProps } from './leafNode';
+import { InnerGlobals } from '../../props/globalProps';
+import { NameValidator } from '../../nameValidator';
+import { Constants } from '../../constants';
+
+export interface CreateEntityNodeProps extends InnerGlobals {
+	tabbable: boolean;
+	level: number;
+	notStartedRenderStrategy: (onClick: () => void) => NodeRenderStrategy;
+	inputRenderStrategy:
+		(inputValue: string,
+			onEnter: () => void,
+			onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void,
+			setInputRefAndFocus: (node: HTMLInputElement) => void) => NodeRenderStrategy;
+	createErrorRenderStrategy: (inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void) => NodeRenderStrategy;
+	inProgressRenderStrategy: (inputValue: string) => NodeRenderStrategy;
+	createEntity: (name: string) => Promise<void>;
+}
+
+export interface CreateEntityNodeState {
+	status: 'NotStarted' | 'Input' | 'CreateError' | 'InProgress';
+	nameInputValue: string;
+}
+
+/**
+ * Functional component for creating a particular entity e.g., notebook. UI logic
+ * should be passed in as props.
+ */
+export class CreateEntityNode extends React.Component<CreateEntityNodeProps, CreateEntityNodeState> {
+	private wrapperRef: HTMLElement;
+	private inputRef: HTMLInputElement;
+	private componentIsMounted: boolean;
+
+	constructor() {
+		super();
+		this.state = this.defaultState();
+
+		this.setWrapperRef = this.setWrapperRef.bind(this);
+		this.setInputRefAndFocus = this.setInputRefAndFocus.bind(this);
+		this.handleClickOutside = this.handleClickOutside.bind(this);
+		this.handleEnterInput = this.handleEnterInput.bind(this);
+		this.resetAndFocus = this.resetAndFocus.bind(this);
+		this.onInputChange = this.onInputChange.bind(this);
+		this.onClick = this.onClick.bind(this);
+	}
+
+	componentDidMount() {
+		document.addEventListener('mousedown', this.handleClickOutside);
+		this.componentIsMounted = true;
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener('mousedown', this.handleClickOutside);
+		this.componentIsMounted = false;
+	}
+
+	private handleClickOutside(event) {
+		if (this.state.status === 'Input' && this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+			this.handleEnterInput();
+		}
+	}
+
+	private handleEnterInput() {
+		if (NameValidator.validateNotebookName(this.state.nameInputValue)) {
+			// Don't fire off request or change state if user attempts to submit invalid name
+			return;
+		}
+
+		// Check for whitespace
+		if (this.state.nameInputValue && this.state.nameInputValue.trim()) {
+			this.setState({ status: 'InProgress' });
+
+			this.props.createEntity(this.state.nameInputValue).then(() => {
+				if (this.componentIsMounted) {
+					this.setState(this.defaultState());
+				}
+			}).catch((error) => {
+				this.setState({
+					status: 'CreateError'
+				});
+			});
+		} else {
+			// User aborted action by clicking out when the input box is empty/whitespace
+			this.resetAndFocus();
+		}
+	}
+
+	private resetAndFocus() {
+		this.setState(this.defaultState());
+		const tabRef = this.wrapperRef.getElementsByTagName('a')[0];
+		if (tabRef) {
+			tabRef.focus();
+		}
+	}
+
+	private defaultState(): CreateEntityNodeState {
+		return {
+			status: 'NotStarted',
+			nameInputValue: ''
+		};
+	}
+
+	render() {
+		const { focusOnMount } = this.props;
+
+		let renderStrategy: NodeRenderStrategy;
+		switch (this.state.status) {
+			case 'Input':
+				renderStrategy = this.props.inputRenderStrategy(this.state.nameInputValue, this.handleEnterInput, this.onInputChange, this.setInputRefAndFocus);
+				break;
+			case 'CreateError':
+				renderStrategy = this.props.createErrorRenderStrategy(this.state.nameInputValue, this.onInputChange);
+				break;
+			case 'InProgress':
+				renderStrategy = this.props.inProgressRenderStrategy(this.state.nameInputValue);
+				break;
+			default:
+				renderStrategy = this.props.notStartedRenderStrategy(this.onClick);
+				break;
+		}
+
+		const props: LeafNodeProps = {
+			node: renderStrategy,
+			treeViewId: Constants.TreeView.id,
+			id: renderStrategy.getId(),
+			level: this.props.level,
+			ariaSelected: renderStrategy.isAriaSelected(), // TODO maybe?
+			tabbable: this.props.tabbable,
+			focusOnMount: focusOnMount,
+
+			globals: this.props,
+		};
+		return (
+			<div ref={this.setWrapperRef}>
+				<LeafNode {...props}></LeafNode>
+			</div>
+		);
+	}
+
+	private setWrapperRef(node) {
+		this.wrapperRef = node as HTMLElement;
+	}
+
+	private onClick() {
+		if (this.state.status === 'NotStarted') {
+			this.setState({
+				status: 'Input'
+			});
+		}
+	}
+
+	private onInputChange(event: React.ChangeEvent<HTMLInputElement>) {
+		this.setState({
+			// We could have been in the error state, so explicitly set status
+			status: 'Input',
+			nameInputValue: event!.target!.value
+		});
+	}
+
+	private setInputRefAndFocus(node: HTMLInputElement) {
+		this.inputRef = node;
+		if (this.inputRef) {
+			this.inputRef.focus();
+		}
+	}
+}

--- a/src/components/treeView/createEntityNode.tsx
+++ b/src/components/treeView/createEntityNode.tsx
@@ -64,28 +64,29 @@ export class CreateEntityNode extends React.Component<CreateEntityNodeProps, Cre
 	}
 
 	private handleEnterInput() {
-		if (NameValidator.validateNotebookName(this.state.nameInputValue)) {
+		if (!this.state.nameInputValue) {
+			// User aborted action by clicking out when the input box is empty/whitespace
+			this.resetAndFocus();
+		}
+
+		const trimmedName = this.state.nameInputValue.trim();
+		if (!trimmedName || NameValidator.validateNotebookName(trimmedName)) {
 			// Don't fire off request or change state if user attempts to submit invalid name
 			return;
 		}
 
-		// Check for whitespace
-		if (this.state.nameInputValue && this.state.nameInputValue.trim()) {
-			this.setState({ status: 'InProgress' });
+		this.setState({ status: 'InProgress' });
 
-			this.props.createEntity(this.state.nameInputValue).then(() => {
-				if (this.componentIsMounted) {
-					this.setState(this.defaultState());
-				}
-			}).catch((error) => {
-				this.setState({
-					status: 'CreateError'
-				});
+		this.props.createEntity(trimmedName).then(() => {
+			if (this.componentIsMounted) {
+				this.setState(this.defaultState());
+			}
+		}).catch((error) => {
+			// TODO (machiam) Add means to show error to the user
+			this.setState({
+				status: 'CreateError'
 			});
-		} else {
-			// User aborted action by clicking out when the input box is empty/whitespace
-			this.resetAndFocus();
-		}
+		});
 	}
 
 	private resetAndFocus() {

--- a/src/components/treeView/expandableNodeRenderStrategy.ts
+++ b/src/components/treeView/expandableNodeRenderStrategy.ts
@@ -1,4 +1,4 @@
-import {NodeRenderStrategy} from './nodeRenderStrategy';
+import { NodeRenderStrategy } from './nodeRenderStrategy';
 
 /**
  * Defines the design and interactability of a TreeView node that

--- a/src/components/treeView/treeViewNavigationUtils.ts
+++ b/src/components/treeView/treeViewNavigationUtils.ts
@@ -7,9 +7,13 @@ export class TreeViewNavigationUtils {
 	 * the scrolling effect on non-tab key presses.
 	 */
 	static normalizeKeyboardEventBehaviour(event: KeyboardEvent) {
+		// Don't block input on inputs
+		if (event.target && (event.target as HTMLElement).tagName.toUpperCase() === 'INPUT') {
+			return;
+		}
+
 		if (event.keyCode !== 13) {
-			// The enter key is the only exception, as this is especially
-			// used to submit forms
+			// The enter/esc keys are the only exception, as this is especially used to submit forms
 			event.stopPropagation();
 		}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,7 @@
 export module Constants {
 	export module TreeView {
 		export const id = 'oneNotePicker';
+		export const createNewNotebookId = 'createNewNotebook';
+		export const createNewSectionIdPrefix = 'createNewSection-';
 	}
 }

--- a/src/localizedComponent.tsx
+++ b/src/localizedComponent.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { Strings } from './strings';
+
+export interface LocalizedComponentProps {
+	stringOverrides: {} | undefined;
+}
+
+/**
+ * Wrapper component that sets localized strings.
+ */
+export class LocalizedComponent extends React.Component<LocalizedComponentProps, {}> {
+	constructor(props: LocalizedComponentProps) {
+		super();
+		Strings.setOverrides(props.stringOverrides);
+	}
+
+	render() {
+		return (<div>{this.props.children}</div>);
+	}
+}

--- a/src/nameValidator.ts
+++ b/src/nameValidator.ts
@@ -1,0 +1,29 @@
+import { Strings } from './strings';
+
+export class NameValidator {
+	private static maxNotebookNameLength: number = 128;
+
+	private static InvalidNotebookNameCharactersRegex: RegExp = new RegExp('[' + String.fromCharCode(
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+		21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 127
+	) + '?*\\/:<>|"#%' + ']');
+
+	static validateNotebookName(name: string): string | undefined {
+		if (/^\./.test(name) || /\.$/.test(name)) {
+			return Strings.get('Error.ValidateNotebookName.NotebookNameDotMessage');
+		}
+
+		if (name.length > NameValidator.maxNotebookNameLength) {
+			const message = Strings.get('Error.ValidateNotebookName.LengthLimitMessage');
+			return message.replace('{0}', '' + NameValidator.maxNotebookNameLength);
+		}
+
+		let matchesArray = name.match(this.InvalidNotebookNameCharactersRegex);
+		if (matchesArray && matchesArray.length > 0) {
+			const message = Strings.get('Error.ValidateNotebookName.ContainsInvalidCharacterMessage');
+			return message.replace('{0}', matchesArray[0]);
+		}
+
+		return undefined;
+	}
+}

--- a/src/oneNoteDataStructures/notebookListUpdater.ts
+++ b/src/oneNoteDataStructures/notebookListUpdater.ts
@@ -2,6 +2,7 @@ import { Notebook } from './notebook';
 import { SectionGroup } from './sectionGroup';
 import { Section } from './section';
 import { Page } from './page';
+import { OneNoteItemUtils } from './oneNoteItemUtils';
 
 type SectionParent = Notebook | SectionGroup;
 
@@ -45,6 +46,22 @@ export class NotebookListUpdater {
 			if (!!originalNotebook) {
 				this.preserveSectionParent(originalNotebook, newNotebook);
 			}
+		}
+	}
+
+	addNotebook(newNotebook: Notebook) {
+		// Always prepend
+		const newNotebooks = [newNotebook, ...this.notebooks];
+		this.notebooks = newNotebooks;
+	}
+
+	addSection(newSection: Section) {
+		const loneParent = newSection.parent!;
+		const parentInHierarchy = OneNoteItemUtils.find(this.notebooks, item => item.id === loneParent.id) as SectionParent | undefined;
+		if (parentInHierarchy) {
+			// Establish two-way reference
+			parentInHierarchy.sections = [newSection, ...parentInHierarchy.sections];
+			newSection.parent = parentInHierarchy;
 		}
 	}
 

--- a/src/oneNotePicker.scss
+++ b/src/oneNotePicker.scss
@@ -10,6 +10,18 @@ svg.spinner {
 	animation: spin 1.3s infinite cubic-bezier(0.53,0.21,0.29,0.67)
 }
 
+@-moz-keyframes spin {
+	from { -moz-transform: rotate(0deg); }
+	to { -moz-transform: rotate(360deg); }
+}
+@-webkit-keyframes spin {
+	from { -webkit-transform: rotate(0deg); }
+	to { -webkit-transform: rotate(360deg); }
+}
+@keyframes spin {
+	from {transform:rotate(0deg);}
+	to {transform:rotate(360deg);}
+}
 
 .onenote-picker {
 	$primary-text-color: #737373;
@@ -39,7 +51,7 @@ svg.spinner {
 		line-height: 1rem;
 		padding: 0.5rem;
 
-		.chevron-icon, .picker-label, .picker-icon, .picker-shared-icon {
+		.chevron-icon, .picker-label, .picker-icon, .picker-shared-icon, .error-info-icon {
 			padding: 0.25rem;
 			order: 4;
 
@@ -74,7 +86,7 @@ svg.spinner {
 				order: 3;
 			}
 
-			label {
+			label, input {
 				overflow: hidden;
 				text-overflow: ellipsis;
 				white-space: nowrap;
@@ -88,6 +100,10 @@ svg.spinner {
 			.breadcrumbs {
 				color: $secondary-text-color;
 				font-size: 0.8rem;
+			}
+
+			.create-label {
+				color: #0078D7;
 			}
 		}
 
@@ -108,6 +124,10 @@ svg.spinner {
 			span {
 				display: none;
 			}
+		}
+
+		.error-info-icon {
+			float: right;
 		}
 
 		&:hover {
@@ -149,6 +169,18 @@ svg.spinner {
 		line-height: 1rem;
 		text-align: center;
 		padding: 0.25rem;
+	}
+
+	.create-input {
+		border: 0;
+		padding: 0;
+		margin: 0;
+		width: 100%;
+		font: inherit;
+	}
+
+	.create-spinner {
+		float: right;
 	}
 }
 

--- a/src/oneNotePicker.tsx
+++ b/src/oneNotePicker.tsx
@@ -11,6 +11,7 @@ import { ExpandableNodeRenderStrategy } from './components/treeView/expandableNo
 import { GlobalProps } from './props/globalProps';
 import { Notebook } from './oneNoteDataStructures/notebook';
 import { SharedNotebook } from './oneNoteDataStructures/sharedNotebook';
+import { CreateNewNotebookNode } from './components/createNewNotebook/createNewNotebookNode';
 
 export interface OneNotePickerProps extends GlobalProps {
 	notebooks: Notebook[];
@@ -30,29 +31,35 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, {}> {
 
 		const noPersonalNotebooks = notebookRenderStrategies.length === 0;
 
+		// The key here is guaranteed to be unique as there is only one max 'Create notebook' affordance
+		const createNewNotebookExists = this.props.globals.callbacks.onNotebookCreated;
+		const createNewNotebook = createNewNotebookExists ?
+			[<CreateNewNotebookNode key='createnewnotebooknode' {...this.props.globals} level={1} tabbable={true} focusOnMount={focusOnMount}></CreateNewNotebookNode>] :
+			[];
+		
 		const notebookNodes = notebookRenderStrategies.map((renderStrategy, i) =>
 			!!this.props.globals.callbacks.onSectionSelected || !!this.props.globals.callbacks.onPageSelected ?
 				<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
 					treeViewId={this.treeViewId()} key={renderStrategy.getId()}
-					id={renderStrategy.getId()} tabbable={i === 0} focusOnMount={focusOnMount && i === 0}
+					id={renderStrategy.getId()} tabbable={!createNewNotebookExists && i === 0} focusOnMount={!createNewNotebookExists && focusOnMount && i === 0}
 					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}></ExpandableNode> :
 				<LeafNode globals={this.props.globals} node={renderStrategy} treeViewId={this.treeViewId()} key={renderStrategy.getId()}
-					id={renderStrategy.getId()} tabbable={i === 0} focusOnMount={focusOnMount && i === 0}
+					id={renderStrategy.getId()} tabbable={!createNewNotebookExists && i === 0} focusOnMount={!createNewNotebookExists && focusOnMount && i === 0}
 					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}></LeafNode>);
 
 		const sharedNotebookNodes = sharedNotebookRenderStrategies.map((renderStrategy, i) =>
 			!!this.props.globals.callbacks.onSectionSelected || !!this.props.globals.callbacks.onPageSelected ?
 				<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
 					treeViewId={this.treeViewId()} key={renderStrategy.getId()}
-					id={renderStrategy.getId()} tabbable={noPersonalNotebooks && i === 0}
-					focusOnMount={focusOnMount && noPersonalNotebooks && i === 0}
+					id={renderStrategy.getId()} tabbable={!createNewNotebookExists && noPersonalNotebooks && i === 0}
+					focusOnMount={!createNewNotebookExists && focusOnMount && noPersonalNotebooks && i === 0}
 					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noPersonalNotebooks && i === 0}></ExpandableNode> :
 				<LeafNode globals={this.props.globals} node={renderStrategy} treeViewId={this.treeViewId()} key={renderStrategy.getId()}
-					id={renderStrategy.getId()} tabbable={noPersonalNotebooks && i === 0}
-					focusOnMount={focusOnMount && noPersonalNotebooks && i === 0}
+					id={renderStrategy.getId()} tabbable={!createNewNotebookExists && noPersonalNotebooks && i === 0}
+					focusOnMount={!createNewNotebookExists && focusOnMount && noPersonalNotebooks && i === 0}
 					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noPersonalNotebooks && i === 0}></LeafNode>);
 
-		return notebookNodes.concat(sharedNotebookNodes);
+		return [...createNewNotebook, ...notebookNodes, ...sharedNotebookNodes];
 	}
 }
 

--- a/src/oneNotePickerBase.tsx
+++ b/src/oneNotePickerBase.tsx
@@ -5,6 +5,7 @@ import './oneNotePicker.scss';
 import { Constants } from './constants';
 import { Strings } from './strings';
 import { GlobalProps } from './props/globalProps';
+import { LocalizedComponent } from './localizedComponent';
 
 export abstract class OneNotePickerBase<TState extends GlobalProps, TProps> extends React.Component<TState, TProps> {
 	protected treeViewId() {
@@ -22,12 +23,14 @@ export abstract class OneNotePickerBase<TState extends GlobalProps, TProps> exte
 
 	render() {
 		return (
-			<div className='onenote-picker ms-fontColor-themePrimary'>
-				<ul role='tree' aria-label={Strings.get('Accessibility.PickerTableName', this.props.globals.strings)}
-					className='menu-list picker-list-header' aria-activedescendant={this.activeDescendentId()}>
-					{this.rootNodes()}
-				</ul>
-			</div>
+			<LocalizedComponent stringOverrides={this.props.globals.strings}>
+				<div className='onenote-picker ms-fontColor-themePrimary'>
+					<ul role='tree' aria-label={Strings.get('Accessibility.PickerTableName')}
+						className='menu-list picker-list-header' aria-activedescendant={this.activeDescendentId()}>
+						{this.rootNodes()}
+					</ul>
+				</div>
+			</LocalizedComponent>
 		);
 	}
 }

--- a/src/oneNoteSingleNotebookDropdown.tsx
+++ b/src/oneNoteSingleNotebookDropdown.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { LocalizedComponent } from './localizedComponent';
+
 import { OneNoteSingleNotebookPickerProps, OneNoteSingleNotebookPicker } from './oneNoteSingleNotebookPicker';
 
 export interface OneNoteSingleNotebookDropdownState {
@@ -80,25 +82,27 @@ export class OneNoteSingleNotebookDropdown extends React.Component<OneNoteSingle
 		newProps.globals.callbacks = newCallbacks;
 
 		return (
-			<div className='picker-dropdown' ref={this.setWrapperRef}>
-				<div className='picker-dropdown-padding'>
-					<a className='picker-dropdown-toggle' onClick={this.onClick.bind(this)}>
-						<div className='dropdown-arrow-container'>
-							<svg version='1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'>
-								<polygon id='XMLID_10_' points='3.5,7 4.4,6.1 8,9.7 11.7,6.1 12.6,7 8,11.5' />
-							</svg>
-						</div>
-						<div className='picker-dropdown-toggle-label' title={this.props.dropdownLabel}>
-							{this.props.dropdownLabel}
-						</div>
-					</a>
+			<LocalizedComponent stringOverrides={this.props.globals.strings}>
+				<div className='picker-dropdown' ref={this.setWrapperRef}>
+					<div className='picker-dropdown-padding'>
+						<a className='picker-dropdown-toggle' onClick={this.onClick.bind(this)}>
+							<div className='dropdown-arrow-container'>
+								<svg version='1' id='Layer_1' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'>
+									<polygon id='XMLID_10_' points='3.5,7 4.4,6.1 8,9.7 11.7,6.1 12.6,7 8,11.5' />
+								</svg>
+							</div>
+							<div className='picker-dropdown-toggle-label' title={this.props.dropdownLabel}>
+								{this.props.dropdownLabel}
+							</div>
+						</a>
+					</div>
+					{this.state.popupVisible ?
+						<div className={'picker-popup ' + (this.props.popupDirection === 'top' ? 'popup-upwards' : '')}>
+							{this.props.popupContentOverride ? this.props.popupContentOverride : <OneNoteSingleNotebookPicker {...newProps} />}
+						</div> :
+						undefined}
 				</div>
-				{this.state.popupVisible ?
-					<div className={'picker-popup ' + (this.props.popupDirection === 'top' ? 'popup-upwards' : '')}>
-						{this.props.popupContentOverride ? this.props.popupContentOverride : <OneNoteSingleNotebookPicker {...newProps} />}
-					</div> :
-					undefined}
-			</div>
+			</LocalizedComponent>	
 		);
 	}
 }

--- a/src/oneNoteSingleNotebookPicker.tsx
+++ b/src/oneNoteSingleNotebookPicker.tsx
@@ -48,6 +48,6 @@ export class OneNoteSingleNotebookPicker extends OneNotePickerBase<OneNoteSingle
 					focusOnMount={focusOnMount && noSectionGroups && i === 0}
 					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noSectionGroups && i === 0}></LeafNode>);
 
-		return sectionNodes.concat(sectionGroupNodes);
+		return [...sectionNodes, ...sectionGroupNodes];
 	}
 }

--- a/src/props/oneNotePickerCallbacks.ts
+++ b/src/props/oneNotePickerCallbacks.ts
@@ -29,4 +29,10 @@ export interface OneNotePickerCallbacks {
 
 	// Accessibility callbacks
 	onAccessibleSelection: (selectedItemId: string) => void;
+	
+	// Create entity callbacks
+	// TODO (machiam) Disallowing creating a notebook after the first one is easy. With sections,
+	// since they are disallowed on a per-notebook basis, is more difficult
+	onNotebookCreated?: (notebook: Notebook) => void;
+	onSectionCreated?: (section: Section) => void;
 }

--- a/src/providers/oneNoteApiDataProvider.ts
+++ b/src/providers/oneNoteApiDataProvider.ts
@@ -4,6 +4,7 @@ import { OneNoteDataProvider } from './oneNoteDataProvider';
 import { Notebook } from '../oneNoteDataStructures/notebook';
 import { OneNoteApiResponseTransformer } from '../oneNoteDataStructures/oneNoteApiResponseTransformer';
 import { Section } from '../oneNoteDataStructures/section';
+import { SectionGroup } from '../oneNoteDataStructures/sectionGroup';
 import { SharedNotebookApiProperties } from '../oneNoteDataStructures/sharedNotebook';
 import { Page } from '../oneNoteDataStructures/page';
 import { SharedNotebook } from '../oneNoteDataStructures/sharedNotebook';
@@ -18,6 +19,27 @@ export class OneNoteApiDataProvider implements OneNoteDataProvider {
 	constructor(private authHeader: string, private timeout?: number, private headers?: { [key: string]: string }) {
 		this.api = new OneNoteApi.OneNoteApi(authHeader, timeout, headers);
 		this.responseTransformer = new OneNoteApiResponseTransformer();
+	}
+
+	createNotebook(name: string): Promise<Notebook> {
+		// tslint:disable-next-line:no-any
+		return this.api.createNotebook(name).then((responsePackage: OneNoteApi.ResponsePackage<any>) => {
+			return Promise.resolve(this.responseTransformer.transformNotebook(responsePackage.parsedResponse));
+		});
+	}
+
+	createSectionUnderNotebook(parent: Notebook, name: string): Promise<Section> {
+		// tslint:disable-next-line:no-any
+		return this.api.createSection(parent.id, name).then((responsePackage: OneNoteApi.ResponsePackage<any>) => {
+			return Promise.resolve(this.responseTransformer.transformSection(responsePackage.parsedResponse, parent));
+		});
+	}
+
+	createSectionUnderSectionGroup(parent: SectionGroup, name: string): Promise<Section> {
+		// tslint:disable-next-line:no-any
+		return this.api.createSection(parent.id, name).then((responsePackage: OneNoteApi.ResponsePackage<any>) => {
+			return Promise.resolve(this.responseTransformer.transformSection(responsePackage.parsedResponse, parent));
+		});
 	}
 
 	getNotebooks(expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<Notebook[]> {

--- a/src/providers/oneNoteDataProvider.ts
+++ b/src/providers/oneNoteDataProvider.ts
@@ -1,4 +1,5 @@
 import { Notebook } from '../oneNoteDataStructures/notebook';
+import { SectionGroup } from '../oneNoteDataStructures/sectionGroup';
 import { Section } from '../oneNoteDataStructures/section';
 import { SharedNotebookApiProperties } from '../oneNoteDataStructures/sharedNotebook';
 import { Page } from '../oneNoteDataStructures/page';
@@ -8,6 +9,10 @@ import { SharedNotebook } from '../oneNoteDataStructures/sharedNotebook';
  * Exposes calls to fetch OneNote data structures.
  */
 export interface OneNoteDataProvider {
+	createNotebook(name: string): Promise<Notebook>;
+	createSectionUnderNotebook(parent: Notebook, name: string): Promise<Section>;
+	createSectionUnderSectionGroup(parent: SectionGroup, name: string): Promise<Section>;
+
 	getNotebooks(expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<Notebook[]>;
 	getPages(section: Section): Promise<Page[]>;
 

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -1,4 +1,6 @@
 export class Strings {
+	private static overrides: {} | undefined;
+
 	private static defaults: {} = {
 		'Shared': 'Shared',
 		'Error.4XX': 'You no longer have access to this notebook.',
@@ -21,19 +23,23 @@ export class Strings {
 		'Input.CreateSectionPlaceholder': 'Untitled Section'
 	};
 
-	static get(key: string, overrides?: {}): string {
-		overrides = overrides || {};
+	static setOverrides(overrides: {} | undefined) {
+		this.overrides = overrides;
+	}
+
+	static get(key: string): string {
+		const overrides = this.overrides || {};
 		return overrides[key] || this.defaults[key] || '';
 	}
 
-	static getError(responseCode: number, overrides?: {}) {
+	static getError(responseCode: number) {
 		const responseStr = responseCode + '';
 		if (responseStr.indexOf('4') === 0) {
-			return this.get('Error.4XX', overrides);
+			return this.get('Error.4XX');
 		}
 		if (responseStr.indexOf('5') === 0) {
-			return this.get('Error.5XX', overrides);
+			return this.get('Error.5XX');
 		}
-		return this.get('Error.Fallback', overrides);
+		return this.get('Error.Fallback');
 	}
 }

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -4,14 +4,24 @@ export class Strings {
 		'Error.4XX': 'You no longer have access to this notebook.',
 		'Error.5XX': 'Something went wrong on our end.',
 		'Error.Fallback': 'Something went wrong.',
+		'Error.ValidateNotebookName.NotebookNameDotMessage': 'Notebook name cannot begin or end with a dot.',
+		'Error.ValidateNotebookName.LengthLimitMessage': 'Notebook name must be less than {0} characters.',
+		'Error.ValidateNotebookName.ContainsInvalidCharacterMessage': 'Notebook name contains invalid character: {0}',
+		'Error.ValidateSectionName.SectionNameDotMessage': 'Section name cannot begin or end with a dot.',
+		'Error.ValidateSectionName.LengthLimitMessage': 'Section name must be less than {0} characters.',
+		'Error.ValidateSectionName.ContainsInvalidCharacterMessage': 'Section name contains invalid character: {0}',
 		'Accessibility.NotebookIcon': 'Notebook Icon',
 		'Accessibility.SectionGroupIcon': 'Section Group Icon',
 		'Accessibility.SectionIcon': 'Section Icon',
 		'Accessibility.PickerTableName': 'Save Locations',
-		'Accessibility.PageIcon': 'Page Icon'
+		'Accessibility.PageIcon': 'Page Icon',
+		'Label.CreateNotebook': 'Create New Notebook',
+		'Label.CreateSection': 'Create New Section',
+		'Input.CreateNotebookPlaceholder': 'Untitled Notebook',
+		'Input.CreateSectionPlaceholder': 'Untitled Section'
 	};
 
-	static get(key: string, overrides?: {}) {
+	static get(key: string, overrides?: {}): string {
 		overrides = overrides || {};
 		return overrides[key] || this.defaults[key] || '';
 	}

--- a/test/nameValidator.spec.ts
+++ b/test/nameValidator.spec.ts
@@ -1,0 +1,34 @@
+import { NameValidator } from '../src/nameValidator';
+
+// TODO (machiam) There's something wrong with `npm run test`, so these aren't running
+describe('NameValidator', () => {
+	it('should allow alphanumeric notebook names', () => {
+		expect(NameValidator.validateNotebookName('foo')).toBeFalsy();
+		expect(NameValidator.validateNotebookName('hello world')).toBeFalsy();
+		expect(NameValidator.validateNotebookName('hello world 123')).toBeFalsy();
+		expect(NameValidator.validateNotebookName('123')).toBeFalsy();
+	});
+
+	it('should not allow empty or whitespace names', () => {
+		expect(NameValidator.validateNotebookName('')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('  ')).toBeTruthy();
+	});
+
+	it('should not allow names beginning or ending with period', () => {
+		expect(NameValidator.validateNotebookName('.hello')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('hello.')).toBeTruthy();
+	});
+
+	it('should not allow certain special characters', () => {
+		expect(NameValidator.validateNotebookName('test ? character')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('test * character')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('test / character')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('test : character')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('test < character')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('test > character')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('test | character')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('test " character')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('test # character')).toBeTruthy();
+		expect(NameValidator.validateNotebookName('test % character')).toBeTruthy();
+	});
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -186,7 +186,7 @@ const analyze = {
 	]
 };
 
-const webpackConfiguration = base;
+let webpackConfiguration = base;
 
 if (IS_PROD) {
 	webpackConfiguration = WebpackMerge(webpackConfiguration, prod);


### PR DESCRIPTION
- Allow users to create notebooks and create sections
  - Create notebooks can be set to allow max one creation
  - Additional work required to set maximum on create section per parent
- Keyboard navigation ready
  - Only issue is that when a new item is created, the picker does not focus to the new item
- If an error happens, we show an error icon, but we do not show any additional info. That comes in another PR.