### PR TITLE
Implement error popovers and keyboard actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9635,6 +9635,12 @@
         "postcss": "5.2.18"
       }
     },
+    "popper.js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
+      "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU=",
+      "dev": true
+    },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
@@ -11242,6 +11248,29 @@
           "dev": true,
           "requires": {
             "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "react-popper": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.10.1.tgz",
+      "integrity": "sha1-ah8llfr/2ncQW+1OiezyJgekxFI=",
+      "dev": true,
+      "requires": {
+        "popper.js": "1.14.3",
+        "prop-types": "15.6.1"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+          "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+          "dev": true,
+          "requires": {
+            "fbjs": "0.8.16",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "files": [
     "dist/**/*"
   ],
@@ -54,6 +54,7 @@
     "react-dev-utils": "^4.1.0",
     "react-dom": "^15.6.2",
     "react-hot-loader": "^1.3.1",
+    "react-popper": "0.10.1",
     "react-test-renderer": "^15.6.2",
     "rimraf": "^2.6.1",
     "sass-loader": "^6.0.5",

--- a/src/components/createNewNotebook/createNewNotebookErrorRenderStrategy.tsx
+++ b/src/components/createNewNotebook/createNewNotebookErrorRenderStrategy.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
-import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
 import { Strings } from '../../strings';
 import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
 import { CreateNewNotebookRowTemplate } from './createNewNotebookRowTemplate';
+import { ErrorIconWithPopover } from '../errorIconWithPopover';
 
 export class CreateNewNotebookErrorRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
 	onClickBinded = () => { };
@@ -12,13 +12,13 @@ export class CreateNewNotebookErrorRenderStrategy extends CreateNewNotebookCommo
 	// We don't listen for enter as we assume that we want the user to change the name before
 	// re-attempting the create
 	constructor(
+		private errorMessage: string,
 		private notebookNameInputValue: string,
 		private onChangeBinded: (event: React.ChangeEvent<HTMLInputElement>) => void) {
 		super();
 	}
 
 	element(): JSX.Element {
-		// TODO (machiam) error info should have a popover as per redlines
 		return (
 			<CreateNewNotebookRowTemplate>
 				<div className='picker-label'>
@@ -30,9 +30,7 @@ export class CreateNewNotebookErrorRenderStrategy extends CreateNewNotebookCommo
 						value={this.notebookNameInputValue}
 						onChange={this.onChangeBinded} />
 				</div>
-				<div className='error-info-icon'>
-					<ErrorInfoIconSvg />
-				</div>
+				<ErrorIconWithPopover errorMessage={this.errorMessage}></ErrorIconWithPopover>
 			</CreateNewNotebookRowTemplate>
 		);
 	}

--- a/src/components/createNewNotebook/createNewNotebookInputRenderStrategy.tsx
+++ b/src/components/createNewNotebook/createNewNotebookInputRenderStrategy.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
 import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
-import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
 import { Strings } from '../../strings';
 import { NameValidator } from '../../nameValidator';
 import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
 import { CreateNewNotebookRowTemplate } from './createNewNotebookRowTemplate';
+import { ErrorIconWithPopover } from '../errorIconWithPopover';
 
 export class CreateNewNotebookInputRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
 	onClickBinded = () => { };
@@ -19,7 +19,6 @@ export class CreateNewNotebookInputRenderStrategy extends CreateNewNotebookCommo
 	}
 
 	element(): JSX.Element {
-		// TODO (machiam) error info should have a popover as per redlines
 		return (
 			<CreateNewNotebookRowTemplate>
 				<div className='picker-label'>
@@ -34,15 +33,13 @@ export class CreateNewNotebookInputRenderStrategy extends CreateNewNotebookCommo
 						onKeyPress={this.onKeyPress.bind(this)}
 						onChange={this.onChangeBinded} />
 				</div>
-				<div className='error-info-icon' style={this.showError() ? { } : { visibility: 'hidden' }}>
-					<ErrorInfoIconSvg />
-				</div>
+				<ErrorIconWithPopover errorMessage={this.errorIfExists()}></ErrorIconWithPopover>
 			</CreateNewNotebookRowTemplate>
 		);
 	}
 
-	private showError(): boolean {
-		return !!NameValidator.validateNotebookName(this.notebookNameInputValue);
+	private errorIfExists(): string | undefined {
+		return NameValidator.validateNotebookName(this.notebookNameInputValue);
 	}
 
 	private onKeyPress(event): void {

--- a/src/components/createNewNotebook/createNewNotebookNode.tsx
+++ b/src/components/createNewNotebook/createNewNotebookNode.tsx
@@ -40,8 +40,8 @@ export class CreateNewNotebookNode extends React.Component<CreateNewNotebookNode
 		return new CreateNewNotebookInputRenderStrategy(inputValue, onEnter, onInputChange, setInputRefAndFocus);
 	}
 
-	private createErrorRenderStrategy(inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void): NodeRenderStrategy {
-		return new CreateNewNotebookErrorRenderStrategy(inputValue, onInputChange);
+	private createErrorRenderStrategy(errorMessage: string, inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void): NodeRenderStrategy {
+		return new CreateNewNotebookErrorRenderStrategy(errorMessage, inputValue, onInputChange);
 	}
 
 	private inProgressRenderStrategy(inputValue: string): NodeRenderStrategy {

--- a/src/components/createNewSection/createNewSectionErrorRenderStrategy.tsx
+++ b/src/components/createNewSection/createNewSectionErrorRenderStrategy.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
-import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
 import { Strings } from '../../strings';
 import { CreateNewSectionCommonProperties } from './createNewSectionCommonProperties';
 import { CreateNewSectionRowTemplate } from './createNewSectionRowTemplate';
+import { ErrorIconWithPopover } from '../errorIconWithPopover';
 
 export class CreateNewSectionErrorRenderStrategy extends CreateNewSectionCommonProperties implements NodeRenderStrategy {
 	onClickBinded = () => { };
@@ -13,13 +13,13 @@ export class CreateNewSectionErrorRenderStrategy extends CreateNewSectionCommonP
 	// re-attempting the create
 	constructor(
 		parentId: string,
+		private errorMessage: string,
 		private sectionNameInputValue: string,
 		private onChangeBinded: (event: React.ChangeEvent<HTMLInputElement>) => void) {
 		super(parentId);
 	}
 
 	element(): JSX.Element {
-		// TODO (machiam) error info should have a popover as per redlines
 		return (
 			<CreateNewSectionRowTemplate>
 				<div className='picker-label'>
@@ -31,9 +31,7 @@ export class CreateNewSectionErrorRenderStrategy extends CreateNewSectionCommonP
 						value={this.sectionNameInputValue}
 						onChange={this.onChangeBinded} />
 				</div>
-				<div className='error-info-icon'>
-					<ErrorInfoIconSvg />
-				</div>
+				<ErrorIconWithPopover errorMessage={this.errorMessage}></ErrorIconWithPopover>
 			</CreateNewSectionRowTemplate>
 		);
 	}

--- a/src/components/createNewSection/createNewSectionInputRenderStrategy.tsx
+++ b/src/components/createNewSection/createNewSectionInputRenderStrategy.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
 import { NodeRenderStrategy } from '../treeView/nodeRenderStrategy';
-import { ErrorInfoIconSvg } from '../icons/errorInfoIcon.svg';
 import { Strings } from '../../strings';
 import { NameValidator } from '../../nameValidator';
 import { CreateNewSectionCommonProperties } from './createNewSectionCommonProperties';
 import { CreateNewSectionRowTemplate } from './createNewSectionRowTemplate';
+import { ErrorIconWithPopover } from '../errorIconWithPopover';
 
 export class CreateNewSectionInputRenderStrategy extends CreateNewSectionCommonProperties implements NodeRenderStrategy {
 	onClickBinded = () => { };
@@ -20,7 +20,6 @@ export class CreateNewSectionInputRenderStrategy extends CreateNewSectionCommonP
 	}
 
 	element(): JSX.Element {
-		// TODO (machiam) error info should have a popover as per redlines
 		return (
 			<CreateNewSectionRowTemplate>
 				<div className='picker-label'>
@@ -34,15 +33,13 @@ export class CreateNewSectionInputRenderStrategy extends CreateNewSectionCommonP
 						onKeyPress={this.onKeyPress.bind(this)}
 						onChange={this.onChangeBinded} />
 				</div>
-				<div className='error-info-icon' style={this.showError() ? { } : { visibility: 'hidden' }}>
-					<ErrorInfoIconSvg />
-				</div>
+				<ErrorIconWithPopover errorMessage={this.errorIfExists()}></ErrorIconWithPopover>
 			</CreateNewSectionRowTemplate>
 		);
 	}
 
-	private showError(): boolean {
-		return !!NameValidator.validateNotebookName(this.notebookNameInputValue);
+	private errorIfExists(): string | undefined {
+		return NameValidator.validateSectionName(this.notebookNameInputValue);
 	}
 
 	private onKeyPress(event): void {

--- a/src/components/createNewSection/createNewSectionNode.tsx
+++ b/src/components/createNewSection/createNewSectionNode.tsx
@@ -44,8 +44,8 @@ export class CreateNewSectionNode extends React.Component<CreateNewSectionNodePr
 		return new CreateNewSectionInputRenderStrategy(this.props.parent.id, inputValue, onEnter, onInputChange, setInputRefAndFocus);
 	}
 
-	private createErrorRenderStrategy(inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void): NodeRenderStrategy {
-		return new CreateNewSectionErrorRenderStrategy(this.props.parent.id, inputValue, onInputChange);
+	private createErrorRenderStrategy(errorMessage: string, inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void): NodeRenderStrategy {
+		return new CreateNewSectionErrorRenderStrategy(this.props.parent.id, errorMessage, inputValue, onInputChange);
 	}
 
 	private inProgressRenderStrategy(inputValue: string): NodeRenderStrategy {

--- a/src/components/errorIconWithPopover.tsx
+++ b/src/components/errorIconWithPopover.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { Manager, Target, Popper, Arrow } from 'react-popper';
+
+import { ErrorInfoIconSvg } from './icons/errorInfoIcon.svg';
+
+export interface ErrorIconWithPopoverProps {
+	errorMessage: string | undefined;
+}
+
+export interface ErrorIconWithPopoverState {
+	popoverIsOpen: boolean;
+}
+
+export class ErrorIconWithPopover extends React.Component<ErrorIconWithPopoverProps, ErrorIconWithPopoverState> {
+	private wrapperRef: Node;
+
+	constructor(props: ErrorIconWithPopoverProps) {
+		super(props);
+
+		this.state = {
+			popoverIsOpen: false
+		};
+
+		// Used to handle if user clicks outside error icon, the popover should close
+		this.setWrapperRef = this.setWrapperRef.bind(this);
+		this.handleClickOutside = this.handleClickOutside.bind(this);
+
+		// Used to handle if the user scrolls anywhere on the page, the popover should close
+		this.scrollHandler = this.scrollHandler.bind(this);
+
+		// Used to handle if the user hits space on the error icon, the popover should toggle visibility
+		this.keyUpHandler = this.keyUpHandler.bind(this);
+
+		// Used to handle if the user clicks the error icon, the popover should toggle visibility
+		this.clickHandler = this.clickHandler.bind(this);
+	}
+
+	componentDidMount() {
+		document.addEventListener('mousedown', this.handleClickOutside);
+		window.addEventListener('scroll', this.scrollHandler, true);
+	}
+
+	componentWillUnmount() {
+		document.removeEventListener('mousedown', this.handleClickOutside);
+		window.removeEventListener('scroll', this.scrollHandler, true);
+	}
+
+	componentWillReceiveProps() {
+		this.setState({
+			popoverIsOpen: false
+		});
+	}
+
+	private handleClickOutside(event) {
+		if (this.wrapperRef && !this.wrapperRef.contains(event.target) && this.state.popoverIsOpen) {
+			this.setState({
+				popoverIsOpen: false
+			});
+		}
+	}
+
+	private setWrapperRef(node) {
+		this.wrapperRef = node as Node;
+	}
+
+	private scrollHandler() {
+		this.setState({
+			popoverIsOpen: false
+		});
+	}
+
+	private keyUpHandler(event) {
+		// Space
+		if (event.keyCode === 32) {
+			this.clickHandler();
+		}
+	}
+
+	private clickHandler() {
+		this.setState({
+			popoverIsOpen: !this.state.popoverIsOpen
+		});
+	}
+
+	render() {
+		return (
+			<div ref={this.setWrapperRef} className='error-info-icon'>
+				<Manager >
+					<Target>
+						<div
+							tabIndex={0}
+							style={this.props.errorMessage ? {} : { visibility: 'hidden' }}
+							onClick={this.clickHandler}
+							onKeyUp={this.keyUpHandler}>
+							<ErrorInfoIconSvg/>
+						</div>
+					</Target>
+					<Popper
+						placement={'bottom'}
+						modifiers={{
+							hide: {
+								enabled: false
+							},
+							preventOverflow: {
+								enabled: true,
+							},
+							arrow: {
+								enabled: true
+							}
+						}}
+						className='error-info-popover popper'
+						eventsEnabled={true}>
+						<div
+							className='error-info-popover-content'
+							style={this.shouldShowPopover() ? {} : { visibility: 'hidden' }}>
+							{this.props.errorMessage}
+						</div>
+						<Arrow className='popper__arrow' />
+					</Popper>
+				</Manager>
+			</div>
+		);
+	}
+
+	private shouldShowPopover() {
+		return this.state.popoverIsOpen;
+	}
+}

--- a/src/components/treeView/createEntityNode.tsx
+++ b/src/components/treeView/createEntityNode.tsx
@@ -15,7 +15,7 @@ export interface CreateEntityNodeProps extends InnerGlobals {
 			onEnter: () => void,
 			onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void,
 			setInputRefAndFocus: (node: HTMLInputElement) => void) => NodeRenderStrategy;
-	createErrorRenderStrategy: (inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void) => NodeRenderStrategy;
+	createErrorRenderStrategy: (errorMessage: string, inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void) => NodeRenderStrategy;
 	inProgressRenderStrategy: (inputValue: string) => NodeRenderStrategy;
 	createEntity: (name: string) => Promise<void>;
 }
@@ -23,6 +23,9 @@ export interface CreateEntityNodeProps extends InnerGlobals {
 export interface CreateEntityNodeState {
 	status: 'NotStarted' | 'Input' | 'CreateError' | 'InProgress';
 	nameInputValue: string;
+	// TODO (machiam) Use the API error in a smarter way to display its message
+	// tslint:disable-next-line:no-any
+	lastError?: any;
 }
 
 /**
@@ -82,9 +85,9 @@ export class CreateEntityNode extends React.Component<CreateEntityNodeProps, Cre
 				this.setState(this.defaultState());
 			}
 		}).catch((error) => {
-			// TODO (machiam) Add means to show error to the user
 			this.setState({
-				status: 'CreateError'
+				status: 'CreateError',
+				lastError: error
 			});
 		});
 	}
@@ -113,7 +116,8 @@ export class CreateEntityNode extends React.Component<CreateEntityNodeProps, Cre
 				renderStrategy = this.props.inputRenderStrategy(this.state.nameInputValue, this.handleEnterInput, this.onInputChange, this.setInputRefAndFocus);
 				break;
 			case 'CreateError':
-				renderStrategy = this.props.createErrorRenderStrategy(this.state.nameInputValue, this.onInputChange);
+				// TODO (machiam) Don't use JSON.stringify; parse out API error instead, or map it to a localized error
+				renderStrategy = this.props.createErrorRenderStrategy(this.state.lastError ? JSON.stringify(this.state.lastError) : '', this.state.nameInputValue, this.onInputChange);
 				break;
 			case 'InProgress':
 				renderStrategy = this.props.inProgressRenderStrategy(this.state.nameInputValue);

--- a/src/nameValidator.ts
+++ b/src/nameValidator.ts
@@ -9,21 +9,48 @@ export class NameValidator {
 	) + '?*\\/:<>|"#%' + ']');
 
 	static validateNotebookName(name: string): string | undefined {
-		if (/^\./.test(name) || /\.$/.test(name)) {
+		if (NameValidator.startsOrEndsWithDot(name)) {
 			return Strings.get('Error.ValidateNotebookName.NotebookNameDotMessage');
 		}
 
-		if (name.length > NameValidator.maxNotebookNameLength) {
+		if (NameValidator.nameTooLong(name)) {
 			const message = Strings.get('Error.ValidateNotebookName.LengthLimitMessage');
 			return message.replace('{0}', '' + NameValidator.maxNotebookNameLength);
 		}
 
-		let matchesArray = name.match(this.InvalidNotebookNameCharactersRegex);
+		const matchesArray = name.match(this.InvalidNotebookNameCharactersRegex);
 		if (matchesArray && matchesArray.length > 0) {
 			const message = Strings.get('Error.ValidateNotebookName.ContainsInvalidCharacterMessage');
 			return message.replace('{0}', matchesArray[0]);
 		}
 
 		return undefined;
+	}
+
+	static validateSectionName(name: string): string | undefined {
+		if (/^\./.test(name) || /\.$/.test(name)) {
+			return Strings.get('Error.ValidateSectionName.SectionNameDotMessage');
+		}
+
+		if (name.length > NameValidator.maxNotebookNameLength) {
+			const message = Strings.get('Error.ValidateSectionName.LengthLimitMessage');
+			return message.replace('{0}', '' + NameValidator.maxNotebookNameLength);
+		}
+
+		const matchesArray = name.match(this.InvalidNotebookNameCharactersRegex);
+		if (matchesArray && matchesArray.length > 0) {
+			const message = Strings.get('Error.ValidateSectionName.ContainsInvalidCharacterMessage');
+			return message.replace('{0}', matchesArray[0]);
+		}
+
+		return undefined;
+	}
+
+	private static startsOrEndsWithDot(name: string): boolean {
+		return /^\./.test(name) || /\.$/.test(name);
+	}
+
+	private static nameTooLong(name: string): boolean {
+		return name.length > NameValidator.maxNotebookNameLength;
 	}
 }

--- a/src/oneNotePicker.scss
+++ b/src/oneNotePicker.scss
@@ -128,6 +128,9 @@ svg.spinner {
 
 		.error-info-icon {
 			float: right;
+			svg {
+				cursor: pointer;
+			}
 		}
 
 		&:hover {
@@ -177,6 +180,10 @@ svg.spinner {
 		margin: 0;
 		width: 100%;
 		font: inherit;
+
+		&::first-line {
+			background-color: #E2E2F6;
+		}
 	}
 
 	.create-spinner {
@@ -201,7 +208,7 @@ svg.spinner {
 		overflow-y: auto;
 		background-color: #FFFFFF;
 		border: 1px solid rgba(22, 35, 58, 0.26);
-		max-height: 140px;
+		max-height: 280px;
 		width: 100%;
 	}
 
@@ -231,6 +238,23 @@ svg.spinner {
 	.dropdown-arrow-container svg polygon {
 		fill: #444545;
 	}
+}
+
+$error-info-popover-color: #6264A7;
+
+.error-info-popover div {
+	// The arrow color is styled using the bottom border runtime style
+	border-bottom-color: $error-info-popover-color !important;
+}
+
+.error-info-popover-content {
+	background-color: $error-info-popover-color;
+	font-size: 10px;
+	line-height: 16px;
+	max-width: 280px;
+	padding: 8px;
+	color: #FFF;
+	border-radius: 4px;
 }
 
 // Default Icon Colors


### PR DESCRIPTION
- Error popover and all related keyboard actions
  - Clicking/hitting space on the icon toggles the popover
  - Clicking away or scrolling hides the popover
- Popover snap upwards if there's not enough space in the picker below it

Issues:
- Arrow is not working - for now we don't display the arrow.