### PR TITLE
Make notebooks selectable, expand with arrows, notebook input callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "2.6.8",
+  "version": "2.7.0",
   "files": [
     "dist/**/*"
   ],

--- a/src/components/createNewNotebook/createNewNotebookInputRenderStrategy.tsx
+++ b/src/components/createNewNotebook/createNewNotebookInputRenderStrategy.tsx
@@ -6,15 +6,17 @@ import { NameValidator } from '../../nameValidator';
 import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
 import { CreateNewNotebookRowTemplate } from './createNewNotebookRowTemplate';
 import { ErrorIconWithPopover } from '../errorIconWithPopover';
+import { OneNotePickerCallbacks } from '../../props/oneNotePickerCallbacks';
 
 export class CreateNewNotebookInputRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
-	onClickBinded = () => { };
+	onClickBinded = this.onClick.bind(this);
 
 	constructor(
 		private notebookNameInputValue: string,
 		private onEnterBinded: (event) => void,
 		private onChangeBinded: (event: React.ChangeEvent<HTMLInputElement>) => void,
-		private inputRefBinded: (node: HTMLInputElement) => void) {
+		private inputRefBinded: (node: HTMLInputElement) => void,
+		private callbacks: OneNotePickerCallbacks) {
 		super();
 	}
 
@@ -31,7 +33,7 @@ export class CreateNewNotebookInputRenderStrategy extends CreateNewNotebookCommo
 						autoComplete='off'
 						value={this.notebookNameInputValue}
 						onKeyPress={this.onKeyPress.bind(this)}
-						onChange={this.onChangeBinded} />
+						onChange={this.onInputChange.bind(this)} />
 				</div>
 				<ErrorIconWithPopover errorMessage={this.errorIfExists()}></ErrorIconWithPopover>
 			</CreateNewNotebookRowTemplate>
@@ -45,6 +47,22 @@ export class CreateNewNotebookInputRenderStrategy extends CreateNewNotebookCommo
 	private onKeyPress(event): void {
 		if (event.key === 'Enter') {
 			this.onEnterBinded(event);
+		}
+	}
+
+	private onInputChange(event): void {
+		const notebookName = (event.target as HTMLInputElement).value;
+		const onNotebookInputValueChanged = this.callbacks.onNotebookInputValueChanged;
+		if (!!onNotebookInputValueChanged) {
+			onNotebookInputValueChanged(notebookName);
+		}
+		this.onChangeBinded(event);
+	}
+
+	private onClick(): void {
+		const onNotebookInputSelected = this.callbacks.onNotebookInputSelected;
+		if (!!onNotebookInputSelected) {
+			onNotebookInputSelected();
 		}
 	}
 }

--- a/src/components/createNewNotebook/createNewNotebookNode.tsx
+++ b/src/components/createNewNotebook/createNewNotebookNode.tsx
@@ -18,18 +18,21 @@ export interface CreateNewNotebookNodeProps extends InnerGlobals {
  * UI.
  */
 export class CreateNewNotebookNode extends React.Component<CreateNewNotebookNodeProps, {}> {
+	private nodeProps: CreateNewNotebookNodeProps;
+
 	constructor(props: CreateNewNotebookNodeProps) {
 		super(props);
+		
+		this.nodeProps = props;
 
 		this.notStartedRenderStrategy = this.notStartedRenderStrategy.bind(this);
 		this.inputRenderStrategy = this.inputRenderStrategy.bind(this);
 		this.createErrorRenderStrategy = this.createErrorRenderStrategy.bind(this);
 		this.inProgressRenderStrategy = this.inProgressRenderStrategy.bind(this);
-		this.createNotebook = this.createNotebook.bind(this);
 	}
 
 	private notStartedRenderStrategy(onClick: () => void): NodeRenderStrategy {
-		return new CreateNewNotebookNotStartedRenderStrategy(onClick);
+		return new CreateNewNotebookNotStartedRenderStrategy(onClick, this.nodeProps.callbacks);
 	}
 
 	private inputRenderStrategy(
@@ -37,7 +40,7 @@ export class CreateNewNotebookNode extends React.Component<CreateNewNotebookNode
 		onEnter: () => void,
 		onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void,
 		setInputRefAndFocus: (node: HTMLInputElement) => void): NodeRenderStrategy {
-		return new CreateNewNotebookInputRenderStrategy(inputValue, onEnter, onInputChange, setInputRefAndFocus);
+		return new CreateNewNotebookInputRenderStrategy(inputValue, onEnter, onInputChange, setInputRefAndFocus, this.nodeProps.callbacks);
 	}
 
 	private createErrorRenderStrategy(errorMessage: string, inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void): NodeRenderStrategy {
@@ -48,12 +51,6 @@ export class CreateNewNotebookNode extends React.Component<CreateNewNotebookNode
 		return new CreateNewNotebookInProgressRenderStrategy(inputValue);
 	}
 
-	private createNotebook(name: string): Promise<void> {
-		return this.props.oneNoteDataProvider!.createNotebook(name).then((notebook) => {
-			return this.props.callbacks.onNotebookCreated!(notebook);
-		});
-	}
-
 	render() {
 		return (
 			<CreateEntityNode
@@ -61,8 +58,7 @@ export class CreateNewNotebookNode extends React.Component<CreateNewNotebookNode
 				notStartedRenderStrategy={this.notStartedRenderStrategy}
 				inputRenderStrategy={this.inputRenderStrategy}
 				createErrorRenderStrategy={this.createErrorRenderStrategy}
-				inProgressRenderStrategy={this.inProgressRenderStrategy}
-				createEntity={this.createNotebook}>
+				inProgressRenderStrategy={this.inProgressRenderStrategy}>
 			</CreateEntityNode>
 		);
 	}

--- a/src/components/createNewNotebook/createNewNotebookNotStartedRenderStrategy.tsx
+++ b/src/components/createNewNotebook/createNewNotebookNotStartedRenderStrategy.tsx
@@ -5,11 +5,14 @@ import { AddIconSvg } from '../icons/addIcon.svg';
 import { ChevronSvg } from '../icons/chevron.svg';
 import { Strings } from '../../strings';
 import { CreateNewNotebookCommonProperties } from './createNewNotebookCommonProperties';
+import { OneNotePickerCallbacks } from '../../props/oneNotePickerCallbacks';
 
 export class CreateNewNotebookNotStartedRenderStrategy extends CreateNewNotebookCommonProperties implements NodeRenderStrategy {
-	onClickBinded = this.onClick;
+	onClickBinded = this.onClickNotebookInput.bind(this);
 
-	constructor(private onClick: () => void) {
+	constructor(
+		private onClick: () => void,
+		private callbacks: OneNotePickerCallbacks) {
 		super();
 	}
 
@@ -27,5 +30,13 @@ export class CreateNewNotebookNotStartedRenderStrategy extends CreateNewNotebook
 				</div>
 			</div>
 		);
+	}
+
+	private onClickNotebookInput(): void {
+		const onNotebookInputSelected = this.callbacks.onNotebookInputSelected;
+		if (!!onNotebookInputSelected) {
+			onNotebookInputSelected();
+		}
+		this.onClick()
 	}
 }

--- a/src/components/notebookRenderStrategy.tsx
+++ b/src/components/notebookRenderStrategy.tsx
@@ -14,14 +14,14 @@ import { ChevronSvg } from './icons/chevron.svg';
 import { CreateNewSectionNode } from './createNewSection/createNewSectionNode';
 
 export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
-	onClickBinded = this.onClick.bind(this);
+	onClickBinded = () => {};
 
 	constructor(private notebook: Notebook, private globals: InnerGlobals) { }
 
 	element(): JSX.Element {
 		return (
-			<div className={this.isSelected() ? 'picker-selectedItem notebook' : 'notebook'} title={this.notebook.name}>
-				<div className={this.isExpanded() ? 'chevron-icon opened' : 'chevron-icon closed'}>
+			<div className={this.isSelected() ? 'picker-selectedItem notebook' : 'notebook'} title={this.notebook.name} onClick={this.onClick.bind(this)}>
+				<div className={this.isExpanded() ? 'chevron-icon opened' : 'chevron-icon closed'} onClick={this.onChevronClick.bind(this)}>
 					<ChevronSvg />
 				</div>
 				<div className='picker-icon'>
@@ -91,14 +91,24 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 		return this.globals.ariaSelectedId ? this.globals.ariaSelectedId === this.getId() : false;
 	}
 
-	private onClick() {
+	expandNode(shouldExpand?: boolean) {
+		if (this.globals.callbacks.onSectionSelected || this.globals.callbacks.onPageSelected) {
+			this.notebook.expanded = shouldExpand == undefined ? !this.notebook.expanded : shouldExpand;
+		}
+	}
+
+	selectNode() {
 		const onNotebookSelected = this.globals.callbacks.onNotebookSelected;
 		if (!!onNotebookSelected) {
 			onNotebookSelected(this.notebook, OneNoteItemUtils.getAncestry(this.notebook));
 		}
+	}
 
-		if (this.globals.callbacks.onSectionSelected || this.globals.callbacks.onPageSelected) {
-			this.notebook.expanded = !this.notebook.expanded;
-		}
+	private onClick() {
+		this.selectNode()
+	}
+
+	private onChevronClick() {
+		this.expandNode()
 	}
 }

--- a/src/components/sectionGroupRenderStrategy.tsx
+++ b/src/components/sectionGroupRenderStrategy.tsx
@@ -18,8 +18,8 @@ export class SectionGroupRenderStrategy implements ExpandableNodeRenderStrategy 
 
 	element(): JSX.Element {
 		return (
-			<div className='section-group' title={this.sectionGroup.name}>
-				<div className={this.isExpanded() ? 'chevron-icon opened' : 'chevron-icon closed'}>
+			<div className='section-group' title={this.sectionGroup.name} onClick={this.onClick.bind(this)}>
+				<div className={this.isExpanded() ? 'chevron-icon opened' : 'chevron-icon closed'} onClick={this.onClick.bind(this)}>
 					<ChevronSvg />
 				</div>
 				<div className='picker-icon'>
@@ -86,8 +86,16 @@ export class SectionGroupRenderStrategy implements ExpandableNodeRenderStrategy 
 		return this.globals.ariaSelectedId ? this.globals.ariaSelectedId === this.getId() : false;
 	}
 
+	expandNode(shouldExpand?: boolean) {
+		this.sectionGroup.expanded = shouldExpand == undefined ? !this.sectionGroup.expanded : shouldExpand;
+	}
+
+	selectNode() {
+		this.expandNode()
+	}
+
 	private onClick() {
 		// No additional functionality
-		this.sectionGroup.expanded = !this.sectionGroup.expanded;
+		this.expandNode()
 	}
 }

--- a/src/components/sharedNotebookRenderStrategy.tsx
+++ b/src/components/sharedNotebookRenderStrategy.tsx
@@ -16,15 +16,15 @@ import { SpinnerIconSvg } from './icons/spinnerIcon.svg';
 import { ChevronSvg } from './icons/chevron.svg';
 
 export class SharedNotebookRenderStrategy implements ExpandableNodeRenderStrategy {
-	onClickBinded = this.onClick.bind(this);
+	onClickBinded = () => {};
 	onExpandBinded = this.onExpand.bind(this);
 
 	constructor(private notebook: SharedNotebook, private globals: InnerGlobals) { }
 
 	element(): JSX.Element {
 		return (
-			<div className={this.isSelected() ? 'picker-selectedItem shared-notebook' : 'shared-notebook'} title={this.breadcrumbs() + '/' + this.notebook.name}>
-				<div className={this.isExpanded() ? 'chevron-icon opened' : 'chevron-icon closed'}>
+			<div className={this.isSelected() ? 'picker-selectedItem shared-notebook' : 'shared-notebook'} title={this.breadcrumbs() + '/' + this.notebook.name} onClick={this.onClick.bind(this)}>
+				<div className={this.isExpanded() ? 'chevron-icon opened' : 'chevron-icon closed'} onClick={this.onChevronClick.bind(this)}>
 					<ChevronSvg />
 				</div>
 				<div className='picker-icon'>
@@ -95,23 +95,33 @@ export class SharedNotebookRenderStrategy implements ExpandableNodeRenderStrateg
 	}
 
 	isSelected(): boolean {
-		return this.notebook.apiProperties ? this.globals.selectedId === this.notebook.apiProperties.id : false;
+		return this.globals.selectedId === this.notebook.webUrl;
 	}
 
 	isAriaSelected(): boolean {
 		return this.globals.ariaSelectedId ? this.globals.ariaSelectedId === this.getId() : false;
 	}
 
-	private onClick() {
+	expandNode(shouldExpand?: boolean) {
+		if (this.globals.callbacks.onSectionSelected || this.globals.callbacks.onPageSelected) {
+			this.notebook.expanded = shouldExpand == undefined ? !this.notebook.expanded : shouldExpand;
+		}
+	}
+
+	selectNode() {
 		const { onNotebookSelected } = this.globals.callbacks;
 
 		if (!!onNotebookSelected) {
 			onNotebookSelected(this.notebook, OneNoteItemUtils.getAncestry(this.notebook));
 		}
+	}
 
-		if (this.globals.callbacks.onSectionSelected || this.globals.callbacks.onPageSelected) {
-			this.notebook.expanded = !this.notebook.expanded;
-		}
+	private onClick() {
+		this.selectNode()
+	}
+
+	private onChevronClick() {
+		this.expandNode()
 	}
 
 	private onExpand() {

--- a/src/components/treeView/createEntityNode.tsx
+++ b/src/components/treeView/createEntityNode.tsx
@@ -17,7 +17,7 @@ export interface CreateEntityNodeProps extends InnerGlobals {
 			setInputRefAndFocus: (node: HTMLInputElement) => void) => NodeRenderStrategy;
 	createErrorRenderStrategy: (errorMessage: string, inputValue: string, onInputChange: (evt: React.ChangeEvent<HTMLInputElement>) => void) => NodeRenderStrategy;
 	inProgressRenderStrategy: (inputValue: string) => NodeRenderStrategy;
-	createEntity: (name: string) => Promise<void>;
+	createEntity?: (name: string) => Promise<void>;
 }
 
 export interface CreateEntityNodeState {
@@ -70,6 +70,10 @@ export class CreateEntityNode extends React.Component<CreateEntityNodeProps, Cre
 		if (!this.state.nameInputValue) {
 			// User aborted action by clicking out when the input box is empty/whitespace
 			this.resetAndFocus();
+		}
+
+		if (!this.props.createEntity) {
+			return
 		}
 
 		const trimmedName = this.state.nameInputValue.trim();

--- a/src/components/treeView/expandableNode.tsx
+++ b/src/components/treeView/expandableNode.tsx
@@ -50,10 +50,18 @@ export class ExpandableNode extends React.Component<ExpandableNodeProps, Expanda
 			case 32:
 				// Space
 				this.onClick();
+
+				if (this.props.node.selectNode) {
+					this.props.node.selectNode()
+				}
 				break;
 			case 37:
 				// Left arrow
 				this.updateExpandedState(false);
+
+				if (this.props.node.expandNode) {
+					this.props.node.expandNode(false)
+				}
 				break;
 			case 39:
 				// Right arrow
@@ -61,6 +69,10 @@ export class ExpandableNode extends React.Component<ExpandableNodeProps, Expanda
 					this.props.node.onExpandBinded();
 				}
 				this.updateExpandedState(true);
+				
+				if (this.props.node.expandNode) {
+					this.props.node.expandNode(true)
+				}
 				break;
 			default:
 				break;
@@ -93,7 +105,7 @@ export class ExpandableNode extends React.Component<ExpandableNodeProps, Expanda
 
 	render() {
 		return (
-			<li aria-labelledby={this.descendentId()} aria-expanded={this.state.expanded} role='treeitem'
+			<li aria-labelledby={this.descendentId()} aria-expanded={this.props.node.isExpanded()} role='treeitem'
 				aria-level={this.level()} aria-checked={this.props.node.isSelected()}
 				id={this.descendentId()} aria-selected={this.props.ariaSelected}>
 				<a className='picker-row' onClick={this.onClick.bind(this)} onKeyDown={this.onKeyDown.bind(this)}
@@ -102,7 +114,7 @@ export class ExpandableNode extends React.Component<ExpandableNodeProps, Expanda
 				   role='presentation'>
 					{this.props.children || this.props.node.element()}
 				</a>
-				{this.state.expanded ?
+				{this.props.node.isExpanded() ?
 					<ul role='group'>
 						{this.props.node.getChildren(this.level() + 1)}
 					</ul> : undefined}

--- a/src/components/treeView/expandableNodeRenderStrategy.ts
+++ b/src/components/treeView/expandableNodeRenderStrategy.ts
@@ -7,4 +7,6 @@ import { NodeRenderStrategy } from './nodeRenderStrategy';
 export interface ExpandableNodeRenderStrategy extends NodeRenderStrategy {
 	getChildren(childrenLevel: number): JSX.Element[];
 	isExpanded(): boolean;
+	expandNode?(shouldExpand?: boolean): void;
+	selectNode?(): void;
 }

--- a/src/props/oneNotePickerCallbacks.ts
+++ b/src/props/oneNotePickerCallbacks.ts
@@ -35,4 +35,7 @@ export interface OneNotePickerCallbacks {
 	// since they are disallowed on a per-notebook basis, is more difficult
 	onNotebookCreated?: (notebook: Notebook) => void;
 	onSectionCreated?: (section: Section) => void;
+
+	onNotebookInputValueChanged?: (name: string) => void;
+	onNotebookInputSelected?: () => void;
 }


### PR DESCRIPTION
Picker redesign for Teams. Users can now select notebooks to save. Can no longer create notebook directly from picker, can only select notebook input to save using callback. Because notebooks can now be selected, clicking row will select, while clicking arrow will expand.