### PR TITLE
Don't alphabetize shared notebook, don't require personal notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "files": [
     "dist/**/*"
   ],

--- a/src/oneNotePicker.tsx
+++ b/src/oneNotePicker.tsx
@@ -27,8 +27,8 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, {}> {
 		const { notebooks, sharedNotebooks, recentSections, globals } = this.props;
 		const { focusOnMount, ariaSelectedId } = globals;
 
-		const notebookRenderStrategies: ExpandableNodeRenderStrategy[] =
-			notebooks.map(notebook => new NotebookRenderStrategy(notebook, globals));
+		const notebookRenderStrategies: ExpandableNodeRenderStrategy[] = notebooks ?
+			notebooks.map(notebook => new NotebookRenderStrategy(notebook, globals)) : [];
 
 		const sharedNotebookRenderStrategies: ExpandableNodeRenderStrategy[] = sharedNotebooks ?
 			sharedNotebooks.map(sharedNotebook => new SharedNotebookRenderStrategy(sharedNotebook, globals)) : [];

--- a/src/providers/oneNoteApiDataProvider.ts
+++ b/src/providers/oneNoteApiDataProvider.ts
@@ -87,18 +87,6 @@ export class OneNoteApiDataProvider implements OneNoteDataProvider {
 				}
 			}
 
-			sharedNotebooks.sort((a, b) => {
-				var nameA = a.name.toUpperCase();
-				var nameB = b.name.toUpperCase();
-				if (nameA < nameB) {
-					return -1;
-				}
-				if (nameA > nameB) {
-					return 1;
-				}
-				return 0;
-			});
-
 			return Promise.resolve(sharedNotebooks);
 		});
 	}


### PR DESCRIPTION
Shared notebooks should be ordered by most recently used, not alphabetized.
Fix for crash if personal notebooks are undefined. 