### PR TITLE
Fix recent sections expand collapse behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "files": [
     "dist/**/*"
   ],

--- a/src/components/recentSections/recentSectionHeaderRenderStrategy.tsx
+++ b/src/components/recentSections/recentSectionHeaderRenderStrategy.tsx
@@ -8,11 +8,12 @@ import { InnerGlobals } from '../../props/globalProps';
 import { Section } from '../../oneNoteDataStructures/section';
 
 export class RecentSectionHeaderRenderStrategy extends RecentSectionsCommonProperties implements ExpandableNodeRenderStrategy {
-	onClickBinded = this.onClick.bind(this);
+	onClickBinded = () => {};
 
-	constructor(private sections: Section[], private expanded: boolean, private props: InnerGlobals) {
+	constructor(private sections: Section[], private expanded: boolean, private props: InnerGlobals, private onRecentSectionsClick: () => void) {
 		super();
 		this.expanded = expanded;
+		this.onClickBinded = this.onRecentSectionsClick;
 	}
 
 	/*
@@ -21,7 +22,7 @@ export class RecentSectionHeaderRenderStrategy extends RecentSectionsCommonPrope
 	Expandable Node component. This allows the Expandable Node component to inform the Recent Sections component of a
 	click event through a callback so that the Recent Sections component can update its state properly. We will revisit
 	this quirk when we refactor the next time.
-	 */
+	*/
 	element(): JSX.Element {
 		return <span></span>;
 	}
@@ -53,9 +54,5 @@ export class RecentSectionHeaderRenderStrategy extends RecentSectionsCommonPrope
 
 	getId() {
 		return Constants.TreeView.recentSectionsId;
-	}
-
-	private onClick() {
-		this.expanded = !this.expanded;
 	}
 }

--- a/src/components/recentSections/recentSectionsNode.tsx
+++ b/src/components/recentSections/recentSectionsNode.tsx
@@ -15,31 +15,25 @@ export interface RecentSectionsNodeProps extends CommonNodeProps {
  * Presentation component that extends the 'Create' UX with notebook-specific
  * UI.
  */
-export class RecentSectionsNode extends React.Component<RecentSectionsNodeProps, { expanded: boolean }> {
-	constructor(props: RecentSectionsNodeProps) {
-		super(props);
-		this.state = {
-			expanded: !!this.props.expanded
-		};
-	}
-
+export class RecentSectionsNode extends React.Component<RecentSectionsNodeProps> {
 	render() {
 		return (
 			<ExpandableNode
-				onExpand={(expanded) => {
-					this.setState({expanded});
-				}}
 				globals={this.props.globals}
-				expanded={this.state.expanded}
+				expanded={this.isExpanded()}
 				node={this.props.node}
 				treeViewId={this.props.treeViewId}
 				id={this.props.id}
 				tabbable={this.props.tabbable}
 				focusOnMount={this.props.focusOnMount}
 				ariaSelected={this.props.ariaSelected}>
-				<RecentSectionHeaderComponent selected={this.props.node.isSelected()} expanded={this.state.expanded}
+				<RecentSectionHeaderComponent selected={this.props.node.isSelected()} expanded={this.isExpanded()}
 											  name={this.props.node.getName()} {...this.props}/>
 			</ExpandableNode>
 		);
+	}
+
+	isExpanded(): boolean {
+		return !!this.props.expanded;
 	}
 }

--- a/src/oneNotePicker.tsx
+++ b/src/oneNotePicker.tsx
@@ -22,10 +22,22 @@ export interface OneNotePickerProps extends GlobalProps {
 	recentSections?: Section[];
 }
 
-export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, {}> {
+export interface OneNotePickerState {
+	recentSectionsExpanded: boolean;
+}
+
+export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, OneNotePickerState> {
+	constructor(props: OneNotePickerProps) {
+		super(props);
+		this.state = {
+			recentSectionsExpanded: true
+		};
+	}
+
 	protected rootNodes(): JSX.Element[] {
 		const { notebooks, sharedNotebooks, recentSections, globals } = this.props;
 		const { focusOnMount, ariaSelectedId } = globals;
+		const { recentSectionsExpanded } = this.state;
 
 		const notebookRenderStrategies: ExpandableNodeRenderStrategy[] = notebooks ?
 			notebooks.map(notebook => new NotebookRenderStrategy(notebook, globals)) : [];
@@ -44,7 +56,7 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, {}> {
 		let recentSectionRenderStrategy, recentSectionsExists = false;
 
 		if (recentSections && recentSections.length > 0) {
-			recentSectionRenderStrategy = new RecentSectionHeaderRenderStrategy(recentSections, true, globals);
+			recentSectionRenderStrategy = new RecentSectionHeaderRenderStrategy(recentSections, recentSectionsExpanded, globals, this.onRecentSectionsClick.bind(this));
 			recentSectionsExists = true;
 		}
 
@@ -53,7 +65,7 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, {}> {
 								 focusOnMount={!createNewNotebookExists && focusOnMount} sections={recentSections || []}
 								 treeViewId={this.treeViewId()} id={recentSectionRenderStrategy.getId()}
 								 ariaSelected={ariaSelectedId ? recentSectionRenderStrategy.isAriaSelected() : true}
-								 node={recentSectionRenderStrategy}></RecentSectionsNode>] : [];
+								 node={recentSectionRenderStrategy} expanded={recentSectionRenderStrategy.isExpanded()}></RecentSectionsNode>] : [];
 
 		const notebookNodes = notebookRenderStrategies.map((renderStrategy, i) =>
 			!!this.props.globals.callbacks.onSectionSelected || !!this.props.globals.callbacks.onPageSelected ?
@@ -78,5 +90,11 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, {}> {
 					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noPersonalNotebooks && i === 0}></LeafNode>);
 
 		return [...recentSectionNodes, ...createNewNotebook, ...notebookNodes, ...sharedNotebookNodes];
+	}
+
+	private onRecentSectionsClick() {
+		this.setState({
+			recentSectionsExpanded: !this.state.recentSectionsExpanded
+		});
 	}
 }


### PR DESCRIPTION
Recent sections were not correctly expanding or collapsing. Move recentSectionsExpanded to OneNotePicker state.