### PR TITLE
Fix sharedNotebooks in picker list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "files": [
     "dist/**/*"
   ],

--- a/src/oneNotePicker.tsx
+++ b/src/oneNotePicker.tsx
@@ -39,9 +39,9 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, OneNote
 		const { recentSectionsExpanded } = this.state;
 
 		// Sort both personal and shared notebooks by last modified time (last accessed time for shared notebooks)
-		const allNotebooks: (Notebook | SharedNotebook)[] = notebooks;
+		let allNotebooks: (Notebook | SharedNotebook)[] = notebooks;
 		if (sharedNotebooks) {
-			allNotebooks.concat(sharedNotebooks);
+			allNotebooks = allNotebooks.concat(sharedNotebooks);
 		}
 		allNotebooks.sort(this.sortNotebooksByLastModifiedTime);
 
@@ -68,7 +68,7 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, OneNote
 								 node={recentSectionRenderStrategy} expanded={recentSectionRenderStrategy.isExpanded()}></RecentSectionsNode>] : [];
 
 		const allNotebookNodes = allNotebooks.map((notebook, i) => {
-			if ((notebook as SharedNotebook).apiProperties) {
+			if ((notebook as SharedNotebook).sourceService) {
 				const renderStrategy = new SharedNotebookRenderStrategy(notebook as SharedNotebook, globals);
 				return !!this.props.globals.callbacks.onSectionSelected || !!this.props.globals.callbacks.onPageSelected ?
 				<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}


### PR DESCRIPTION
- Fix all notebooks to reassign array after concat with sharedNotebooks

- Use sourceService to determine if notebook is sharedNotebook as this is always set, and apiProperties may not be set