### PR TITLE
Add parent notebook name to section interface and recent section rendered component.

### DIFF
--- a/src/oneNoteDataStructures/section.ts
+++ b/src/oneNoteDataStructures/section.ts
@@ -7,5 +7,6 @@ export interface Section extends OneNoteItem {
 	apiUrl: string;
 	webUrl?: string;
 	clientUrl?: string;
+	isRecentSection?: boolean;
 	parentNotebookName?: string;
 }


### PR DESCRIPTION
We want to display the parent notebook's name instead of the immediate parent's name (which could be a section group) in the recent section component for clarity. 