### PR TITLE
Add parent notebook name to recent section component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "2.7.13",
+  "version": "2.7.14",
   "files": [
     "dist/**/*"
   ],

--- a/src/components/recentSections/recentSectionRenderStrategy.tsx
+++ b/src/components/recentSections/recentSectionRenderStrategy.tsx
@@ -19,7 +19,7 @@ export class RecentSectionRenderStrategy implements NodeRenderStrategy {
 				</div>
 				<div className='picker-label'>
 					<label>{this.section.name}</label>
-					<label className='parent'>{this.section.parent ? this.section.parent.name : ''}</label>
+					<label className='parent'>{this.section.parentNotebookName ? this.section.parentNotebookName : ''}</label>
 				</div>
 			</div>
 		);

--- a/src/oneNoteDataStructures/section.ts
+++ b/src/oneNoteDataStructures/section.ts
@@ -7,5 +7,6 @@ export interface Section extends OneNoteItem {
 	apiUrl: string;
 	webUrl?: string;
 	clientUrl?: string;
+	isRecentSection?: boolean;
 	parentNotebookName?: string;
 }


### PR DESCRIPTION
In the recent sections component, we want to display the parent notebook's name, not the direct parent's (which could be a section group and is not as useful for the user). 