### PR TITLE
Fix recent section header expand collapse behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "2.7.19",
+  "version": "2.7.20",
   "files": [
     "dist/**/*"
   ],

--- a/src/components/recentSections/recentSectionHeaderComponent.tsx
+++ b/src/components/recentSections/recentSectionHeaderComponent.tsx
@@ -7,6 +7,7 @@ export interface RecentSectionHeaderProps extends RecentSectionsNodeProps {
 	selected: boolean;
 	expanded: boolean;
 	name: string;
+	onRecentSectionsClick: (expanded: boolean) => void;
 }
 
 export class RecentSectionHeaderComponent extends React.Component<RecentSectionHeaderProps, {}> {
@@ -18,7 +19,7 @@ export class RecentSectionHeaderComponent extends React.Component<RecentSectionH
 		return (
 			<div className={this.props.selected ? 'picker-selectedItem recent-sections' : 'recent-sections'}
 				 title='recent-sections'>
-				<div className={this.props.expanded ? 'chevron-icon opened' : 'chevron-icon closed'}>
+				<div className={this.props.expanded ? 'chevron-icon opened' : 'chevron-icon closed'} onClick={this.onChevronClick.bind(this)}>
 					<ChevronSvg/>
 				</div>
 				<div className='picker-icon'>
@@ -29,5 +30,9 @@ export class RecentSectionHeaderComponent extends React.Component<RecentSectionH
 				</div>
 			</div>
 		);
+	}
+
+	private onChevronClick() {
+		this.props.onRecentSectionsClick(!this.props.expanded);
 	}
 }

--- a/src/components/recentSections/recentSectionHeaderRenderStrategy.tsx
+++ b/src/components/recentSections/recentSectionHeaderRenderStrategy.tsx
@@ -9,11 +9,14 @@ import { Section } from '../../oneNoteDataStructures/section';
 
 export class RecentSectionHeaderRenderStrategy extends RecentSectionsCommonProperties implements ExpandableNodeRenderStrategy {
 	onClickBinded = () => {};
+	onExpandBinded = () => {};
+	onCollapseBinded = () => {};
 
-	constructor(private sections: Section[], private expanded: boolean, private props: InnerGlobals, private onRecentSectionsClick: () => void) {
+	constructor(private sections: Section[], private expanded: boolean, private props: InnerGlobals, private onRecentSectionsClick: (expanded: boolean) => void) {
 		super();
 		this.expanded = expanded;
-		this.onClickBinded = this.onRecentSectionsClick;
+		this.onExpandBinded = () => { this.onRecentSectionsClick(true); };
+		this.onCollapseBinded = () => { this.onRecentSectionsClick(false); };
 	}
 
 	/*

--- a/src/components/recentSections/recentSectionsNode.tsx
+++ b/src/components/recentSections/recentSectionsNode.tsx
@@ -9,6 +9,7 @@ export interface RecentSectionsNodeProps extends CommonNodeProps {
 	sections: Section[];
 	expanded?: boolean;
 	node: ExpandableNodeRenderStrategy;
+	onRecentSectionsClick: (expanded: boolean) => void;
 }
 
 /**
@@ -28,7 +29,7 @@ export class RecentSectionsNode extends React.Component<RecentSectionsNodeProps>
 				focusOnMount={this.props.focusOnMount}
 				ariaSelected={this.props.ariaSelected}>
 				<RecentSectionHeaderComponent selected={this.props.node.isSelected()} expanded={this.isExpanded()}
-											  name={this.props.node.getName()} {...this.props}/>
+					name={this.props.node.getName()} {...this.props} onRecentSectionsClick={this.props.onRecentSectionsClick}/>
 			</ExpandableNode>
 		);
 	}

--- a/src/components/treeView/expandableNode.tsx
+++ b/src/components/treeView/expandableNode.tsx
@@ -28,15 +28,7 @@ export class ExpandableNode extends React.Component<ExpandableNodeProps, Expanda
 
 	onClick() {
 		const {node} = this.props;
-		const nextExpandState = !this.state.expanded;
-
-		this.updateExpandedState(nextExpandState);
-
-		if (nextExpandState && node.onExpandBinded) {
-			node.onExpandBinded();
-		}
 		node.onClickBinded();
-
 		this.props.globals.callbacks.onAccessibleSelection(node.getId());
 	}
 
@@ -57,6 +49,10 @@ export class ExpandableNode extends React.Component<ExpandableNodeProps, Expanda
 				break;
 			case 37:
 				// Left arrow
+				if (this.props.node.onCollapseBinded) {
+					this.props.node.onCollapseBinded();
+				}
+
 				this.updateExpandedState(false);
 
 				if (this.props.node.expandNode) {

--- a/src/components/treeView/nodeRenderStrategy.ts
+++ b/src/components/treeView/nodeRenderStrategy.ts
@@ -5,6 +5,7 @@
 export interface NodeRenderStrategy {
 	onClickBinded: () => void;
 	onExpandBinded?: () => void;
+	onCollapseBinded?: () => void;
 	element(): JSX.Element;
 	getId(): string;
 	getName(): string;

--- a/src/oneNotePicker.tsx
+++ b/src/oneNotePicker.tsx
@@ -65,7 +65,8 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, OneNote
 								 focusOnMount={!createNewNotebookExists && focusOnMount} sections={recentSections || []}
 								 treeViewId={this.treeViewId()} id={recentSectionRenderStrategy.getId()}
 								 ariaSelected={ariaSelectedId ? recentSectionRenderStrategy.isAriaSelected() : true}
-								 node={recentSectionRenderStrategy} expanded={recentSectionRenderStrategy.isExpanded()}></RecentSectionsNode>] : [];
+								 node={recentSectionRenderStrategy} expanded={recentSectionRenderStrategy.isExpanded()}
+								 onRecentSectionsClick={this.onRecentSectionsClick.bind(this)}></RecentSectionsNode>] : [];
 
 		const allNotebookNodes = allNotebooks.map((notebook, i) => {
 			if ((notebook as SharedNotebook).sourceService) {
@@ -96,9 +97,9 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, OneNote
 		return [...recentSectionNodes, ...createNewNotebook, ...allNotebookNodes];
 	}
 
-	private onRecentSectionsClick() {
+	private onRecentSectionsClick(expanded: boolean) {
 		this.setState({
-			recentSectionsExpanded: !this.state.recentSectionsExpanded
+			recentSectionsExpanded: expanded
 		});
 	}
 


### PR DESCRIPTION
Recent section header expands and collapses with space, but not arrows, whereas all other notebooks/sectiongroups expand/collapse with arrows. Update recent section header to match other behavior.