### PR TITLE
Fix picker tab index so tabbing behavior is correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "files": [
     "dist/**/*"
   ],

--- a/src/components/recentSections/recentSectionHeaderRenderStrategy.tsx
+++ b/src/components/recentSections/recentSectionHeaderRenderStrategy.tsx
@@ -37,7 +37,7 @@ export class RecentSectionHeaderRenderStrategy extends RecentSectionsCommonPrope
 			<LeafNode globals={this.props} node={renderStrategy} treeViewId={Constants.TreeView.id}
 					  key={renderStrategy.getId() + 'recent-section'}
 					  id={renderStrategy.getId()}
-					  ariaSelected={this.props.ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}
+					  ariaSelected={this.props.ariaSelectedId ? renderStrategy.isAriaSelected() : false}
 					  level={childrenLevel} setsize={this.sections.length} posinset={i + 1}></LeafNode>);
 
 		return [...sections];

--- a/src/components/treeView/expandableNode.tsx
+++ b/src/components/treeView/expandableNode.tsx
@@ -111,7 +111,7 @@ export class ExpandableNode extends React.Component<ExpandableNodeProps, Expanda
 			<li>
 				<a id={this.descendentId()} className='picker-row' onClick={this.onClick.bind(this)} onKeyDown={this.onKeyDown.bind(this)}
 				   data-treeviewid={this.props.treeViewId} data-id={this.props.id}
-				   tabIndex={this.props.tabbable ? 0 : -1} role='treeitem' aria-labelledby={this.descendentId()} 
+				   tabIndex={this.props.ariaSelected ? 0 : -1} role='treeitem' aria-labelledby={this.descendentId()} 
 				   aria-expanded={this.props.node.isExpanded()} aria-selected={this.props.ariaSelected}
 				   aria-level={this.level()} aria-setsize={this.props.setsize} aria-posinset={this.props.posinset}>
 					{this.props.children || this.props.node.element()}

--- a/src/components/treeView/leafNode.tsx
+++ b/src/components/treeView/leafNode.tsx
@@ -49,7 +49,7 @@ export class LeafNode extends React.Component<LeafNodeProps, {}> {
 		return (
 			<li>
 				<a id={this.descendentId()} className='picker-row' onClick={this.onClick.bind(this)} onKeyDown={this.onKeyDown.bind(this)}
-					data-treeviewid={this.props.treeViewId} data-id={this.props.id} tabIndex={this.props.tabbable ? 0 : -1}
+					data-treeviewid={this.props.treeViewId} data-id={this.props.id} tabIndex={this.props.ariaSelected ? 0 : -1}
 					role='treeitem' aria-labelledby={this.descendentId()} aria-level={this.level()}
 					aria-selected={this.props.ariaSelected} aria-setsize={this.props.setsize} aria-posinset={this.props.posinset}>
 					{this.props.node.element()}

--- a/src/oneNotePicker.tsx
+++ b/src/oneNotePicker.tsx
@@ -75,24 +75,24 @@ export class OneNotePicker extends OneNotePickerBase<OneNotePickerProps, OneNote
 				<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
 					treeViewId={this.treeViewId()} key={renderStrategy.getId()}
 					id={renderStrategy.getId()} tabbable={!createNewNotebookExists && noPersonalNotebooks && i === 0}
-					focusOnMount={!createNewNotebookExists && !recentSectionsExists && focusOnMount && noPersonalNotebooks && i === 0}
-					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noPersonalNotebooks && i === 0}
+					focusOnMount={!createNewNotebookExists && !recentSectionsExists && focusOnMount && i === 0}
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : !recentSectionsExists && i === 0}
 					setsize={allNotebooks.length} posinset={i + 1}></ExpandableNode> :
 				<LeafNode globals={this.props.globals} node={renderStrategy} treeViewId={this.treeViewId()} key={renderStrategy.getId()}
 					id={renderStrategy.getId()} tabbable={!createNewNotebookExists && noPersonalNotebooks && i === 0}
-					focusOnMount={!createNewNotebookExists && !recentSectionsExists && focusOnMount && noPersonalNotebooks && i === 0}
-					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : noPersonalNotebooks && i === 0}></LeafNode>;
+					focusOnMount={!createNewNotebookExists && !recentSectionsExists && focusOnMount && i === 0}
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : !recentSectionsExists && i === 0}></LeafNode>;
 			} else {
 				const renderStrategy = new NotebookRenderStrategy(notebook, globals);
 				return !!this.props.globals.callbacks.onSectionSelected || !!this.props.globals.callbacks.onPageSelected ?
 				<ExpandableNode globals={this.props.globals} expanded={renderStrategy.isExpanded()} node={renderStrategy}
 					treeViewId={this.treeViewId()} key={renderStrategy.getId()}
 					id={renderStrategy.getId()} tabbable={!createNewNotebookExists && !recentSectionsExists && i === 0} focusOnMount={!createNewNotebookExists && !recentSectionsExists && focusOnMount && i === 0}
-					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : !recentSectionsExists && i === 0}
 					setsize={allNotebooks.length} posinset={i + 1}></ExpandableNode> :
 				<LeafNode globals={this.props.globals} node={renderStrategy} treeViewId={this.treeViewId()} key={renderStrategy.getId()}
 					id={renderStrategy.getId()} tabbable={!createNewNotebookExists && i === 0} focusOnMount={!createNewNotebookExists && !recentSectionsExists && focusOnMount && i === 0}
-					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : i === 0}></LeafNode>;
+					ariaSelected={ariaSelectedId ? renderStrategy.isAriaSelected() : !recentSectionsExists && i === 0}></LeafNode>;
 			}
 		})
 


### PR DESCRIPTION
- Set tab index to 0 for last keyboard navigated picker item, and -1 for everything else. This allows user to tab back to their last visited picker item.
- Focus first picker item correctly on initial load of the picker