### PR TITLE
Add focusable false to svg's which were being focused in win32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "files": [
     "dist/**/*"
   ],

--- a/src/components/icons/chevron.svg.tsx
+++ b/src/components/icons/chevron.svg.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 export class ChevronSvg extends React.Component {
 	render() {
 		return (
-			<svg className='chevron-icon' viewBox='0 0 15 8' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink'>
+			<svg className='chevron-icon' viewBox='0 0 15 8' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink' focusable="false">
 				<g stroke='none' strokeWidth='1' fill='none' fillRule='evenodd'>
 					<g fill='currentColor'>
 						<polygon id='Triangle' points='7.5 0 15 8 0 8'/>

--- a/src/components/icons/notebookClosedIcon.svg.tsx
+++ b/src/components/icons/notebookClosedIcon.svg.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 export class NotebookClosedIconSvg extends React.Component {
 	render() {
 		return (
-			<svg className='notebook-closed-icon' viewBox='0 0 14 14' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink'>
+			<svg className='notebook-closed-icon' viewBox='0 0 14 14' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink' focusable="false">
 				<g className='icon-container' stroke='none' strokeWidth='1' fill='currentColor' fillRule='evenodd'>
 					<path d='M13.5,9 L12,9 L12,12 L13.5,12 C13.741,12 14,11.53 14,10.5 C14,9.47 13.741,9 13.5,9 Z'/>
 					<path d='M12,5 L12,8 L13.5,8 C13.741,8 14,7.531 14,6.5 C14,5.469 13.741,5 13.5,5 L12,5 Z'/>

--- a/src/components/icons/notebookOpenedIcon.svg.tsx
+++ b/src/components/icons/notebookOpenedIcon.svg.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 export class NotebookOpenedIconSvg extends React.Component {
 	render() {
 		return (
-			<svg className='notebook-opened-icon' viewBox='0 0 16 14' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink'>
+			<svg className='notebook-opened-icon' viewBox='0 0 16 14' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink' focusable="false">
 				<g id='icon-container' stroke='none' strokeWidth='1' fill='currentColor' fillRule='evenodd'>
 					<path d='M14.5,1 C15.053,1 15.5,1.447 15.5,2 L15.5,13 C15.5,13.553 15.053,14 14.5,14 L1.5,14 C0.947,14 0.5,13.553 0.5,13 L0.5,2 C0.5,1.447 0.947,1 1.5,1 L1.5,0 C3.26,0 5.731,0.373 7.186,1 L8.814,1 C10.269,0.373 12.74,0 14.5,0 L14.5,1 Z M7.5,13 L7.5,2.5 C6.57,1.76 4.35,1.06 2.5,1 L2.5,11.5 C4.28,11.55 6.43,12.31 7.5,13 Z M13.5,11.5 L13.5,1 C11.33,1.06 9.59,1.76 8.5,2.5 L8.5,13 C9.76,12.31 11.41,11.55 13.5,11.5 Z' />
 				</g>

--- a/src/components/icons/sectionGroupIcon.svg.tsx
+++ b/src/components/icons/sectionGroupIcon.svg.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 export class SectionGroupIconSvg extends React.Component {
 	render() {
 		return (
-			<svg className='section-group-icon' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink' viewBox='0 0 20 20'>
+			<svg className='section-group-icon' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlnsXlink='http://www.w3.org/1999/xlink' viewBox='0 0 20 20' focusable="false">
 				<path d='M13,3H7v14h6v2h1V1h-1V3z' className='primary-section-outline' fill='currentColor'/>
 				<polygon points='11,1 5,1 5,15 6,15 6,2 11,2' className='secondary-section-outline' fill='currentColor'/>
 			</svg>

--- a/src/components/icons/sectionIcon.svg.tsx
+++ b/src/components/icons/sectionIcon.svg.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 export class SectionIconSvg extends React.Component {
 	render() {
 		return (
-			<svg className='section-icon' version='1.1' xmlns='http://www.w3.org/2000/svg'
+			<svg className='section-icon' version='1.1' xmlns='http://www.w3.org/2000/svg' focusable="false"
 				xmlnsXlink='http://www.w3.org/1999/xlink' viewBox='0 0 20 20' fill='currentColor'>
 				<path d='M12,3H6v14h6v2h1V1h-1V3z'/>
 			</svg>


### PR DESCRIPTION
Svg's were focusable for some reason in Outlook win32 for the picker. And tabIndex was not being respected for them, so used focusable="false" instead.