### PR TITLE
Linswu/add notebook children loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onenotepicker",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "files": [
     "dist/**/*"
   ],

--- a/src/components/notebookRenderStrategy.tsx
+++ b/src/components/notebookRenderStrategy.tsx
@@ -54,7 +54,7 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 			];
 		}
 
-		if (this.notebook.needsToFetchChildren) {
+		if (!this.notebook.sections && !this.notebook.sectionGroups) {
 			return [
 				<li className='progress-row'>
 					<SpinnerIconSvg />
@@ -76,6 +76,10 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 			</CreateNewSectionNode>] :
 			[];
 
+		if (!this.notebook.sections || !this.notebook.sectionGroups) {
+			return [...createNewSection]
+		}
+
 		const setsize = this.notebook.sections.length + this.notebook.sectionGroups.length;
 
 		const sectionGroupRenderStrategies = this.notebook.sectionGroups.map(sectionGroup => new SectionGroupRenderStrategy(sectionGroup, this.globals));
@@ -85,7 +89,7 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 					expanded={renderStrategy.isExpanded()} node={renderStrategy} globals={this.globals}
 					treeViewId={Constants.TreeView.id} key={renderStrategy.getId()}
 					id={renderStrategy.getId()} level={childrenLevel} ariaSelected={renderStrategy.isAriaSelected()} selected={renderStrategy.isSelected()}
-					setsize={setsize} posinset={this.notebook.sections.length + i + 1} /> :
+					setsize={setsize} posinset={this.notebook.sections ? this.notebook.sections.length + i + 1 : undefined} /> :
 				<LeafNode node={renderStrategy} treeViewId={Constants.TreeView.id} key={renderStrategy.getId()} globals={this.globals}
 					id={renderStrategy.getId()} level={childrenLevel} ariaSelected={renderStrategy.isAriaSelected()} />);
 
@@ -143,7 +147,7 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 	}
 
 	private onExpand() {
-		if (this.notebook.needsToFetchChildren && this.notebook.apiUrl && this.globals.oneNoteDataProvider) {
+		if (!this.notebook.sections && !this.notebook.sectionGroups && this.notebook.apiUrl && this.globals.oneNoteDataProvider) {
 			this.globals.oneNoteDataProvider.getNotebookBySelfUrl(this.notebook.apiUrl, 5).then((notebook) => {
 				this.notebook.sections = notebook.sections
 				this.notebook.sectionGroups = notebook.sectionGroups
@@ -154,7 +158,6 @@ export class NotebookRenderStrategy implements ExpandableNodeRenderStrategy {
 					this.notebook.apiHttpErrorMessage = Strings.getError(apiError.statusCode);
 				}
 			}).then(() => {
-				this.notebook.needsToFetchChildren = false;
 				if (this.globals.callbacks.onNotebookInfoReturned) {
 					this.globals.callbacks.onNotebookInfoReturned(this.notebook);
 				}

--- a/src/oneNoteDataStructures/notebook.ts
+++ b/src/oneNoteDataStructures/notebook.ts
@@ -4,7 +4,7 @@ import { SectionGroup } from './sectionGroup';
 
 export interface Notebook extends OneNoteItem {
 	// Properties that need to be loaded-on-demand
-	apiHttpErrorCode?: number;
+	apiHttpErrorMessage?: string;
 
 	expanded: boolean;
 	sectionGroups: SectionGroup[];

--- a/src/oneNoteDataStructures/notebook.ts
+++ b/src/oneNoteDataStructures/notebook.ts
@@ -7,10 +7,9 @@ export interface Notebook extends OneNoteItem {
 	apiHttpErrorMessage?: string;
 
 	expanded: boolean;
-	sectionGroups: SectionGroup[];
-	sections: Section[];
+	sectionGroups?: SectionGroup[];
+	sections?: Section[];
 	webUrl: string;
 	apiUrl?: string;
 	lastModifiedTime: Date;
-	needsToFetchChildren?: boolean
 }

--- a/src/oneNoteDataStructures/notebook.ts
+++ b/src/oneNoteDataStructures/notebook.ts
@@ -3,10 +3,14 @@ import { Section } from './section';
 import { SectionGroup } from './sectionGroup';
 
 export interface Notebook extends OneNoteItem {
+	// Properties that need to be loaded-on-demand
+	apiHttpErrorCode?: number;
+
 	expanded: boolean;
 	sectionGroups: SectionGroup[];
 	sections: Section[];
 	webUrl: string;
 	apiUrl?: string;
 	lastModifiedTime: Date;
+	needsToFetchChildren?: boolean
 }

--- a/src/oneNoteDataStructures/notebookListUpdater.ts
+++ b/src/oneNoteDataStructures/notebookListUpdater.ts
@@ -58,7 +58,7 @@ export class NotebookListUpdater {
 	addSection(newSection: Section) {
 		const loneParent = newSection.parent!;
 		const parentInHierarchy = OneNoteItemUtils.find(this.notebooks, item => item.id === loneParent.id) as SectionParent | undefined;
-		if (parentInHierarchy) {
+		if (parentInHierarchy && parentInHierarchy.sections) {
 			// Establish two-way reference
 			parentInHierarchy.sections = [newSection, ...parentInHierarchy.sections];
 			newSection.parent = parentInHierarchy;
@@ -68,6 +68,11 @@ export class NotebookListUpdater {
 	private preserveSectionParent(original: SectionParent, next: SectionParent) {
 		// Preserve properties we want to keep from the original object ...
 		next.expanded = original.expanded;
+
+		if (!original.sections || !original.sectionGroups || 
+			!next.sections || !next.sectionGroups) {
+			return;
+		}
 
 		// ... then recurse through the children
 		for (let newSectionGroup of next.sectionGroups) {
@@ -118,6 +123,10 @@ export class NotebookListUpdater {
 	}
 
 	private getSectionRefFromSectionParent(sectionId: string, sectionParent: SectionParent): Section | undefined {
+		if (!sectionParent.sections || !sectionParent.sectionGroups) {
+			return undefined;
+		}
+		
 		// Search this parent's sections for the matching id ...
 		for (let childSection of sectionParent.sections) {
 			if (childSection.id === sectionId) {

--- a/src/oneNoteDataStructures/oneNoteApiResponseTransformer.ts
+++ b/src/oneNoteDataStructures/oneNoteApiResponseTransformer.ts
@@ -30,8 +30,8 @@ export class OneNoteApiResponseTransformer {
 			lastModifiedTime: notebook.lastModifiedTime
 		};
 
-		transformed.sectionGroups = notebook.sectionGroups ? notebook.sectionGroups.map(sg => this.transformSectionGroup(sg, transformed)) : [];
-		transformed.sections = notebook.sections ? notebook.sections.map(section => this.transformSection(section, transformed)) : [];
+		transformed.sectionGroups = notebook.sectionGroups ? notebook.sectionGroups.map(sg => this.transformSectionGroup(sg, transformed)) : undefined;
+		transformed.sections = notebook.sections ? notebook.sections.map(section => this.transformSection(section, transformed)) : undefined;
 
 		return transformed;
 	}

--- a/src/oneNoteDataStructures/oneNoteItemUtils.ts
+++ b/src/oneNoteDataStructures/oneNoteItemUtils.ts
@@ -29,6 +29,10 @@ export class OneNoteItemUtils {
 				sectionGroups = sectionParentNotebook.apiProperties.spSectionGroups;
 				sections = sectionParentNotebook.apiProperties.spSections;
 			} else {
+				if (!sectionParent.sections || !sectionParent.sectionGroups) {
+					continue;
+				}
+
 				sectionGroups = sectionParent.sectionGroups;
 				sections = sectionParent.sections;
 			}
@@ -93,6 +97,10 @@ export class OneNoteItemUtils {
 	 * one descendent section; false otherwise.
 	 */
 	static prune(root: Notebook | SectionGroup): boolean {
+		if (!root.sections || !root.sectionGroups) {
+			return false
+		}
+
 		root.sectionGroups = root.sectionGroups.filter(OneNoteItemUtils.prune);
 		return root.sectionGroups.length > 0 || root.sections.length > 0;
 	}

--- a/src/oneNoteDataStructures/sharedNotebook.ts
+++ b/src/oneNoteDataStructures/sharedNotebook.ts
@@ -9,7 +9,6 @@ import { SectionGroup } from './sectionGroup';
 export interface SharedNotebook extends Notebook {
 	// Properties that need to be loaded-on-demand
 	apiProperties?: SharedNotebookApiProperties;
-	apiHttpErrorCode?: number;
 	startedLoading?: boolean;
 
 	// Properties returned from GetRecentNotebooks

--- a/src/props/oneNotePickerCallbacks.ts
+++ b/src/props/oneNotePickerCallbacks.ts
@@ -22,6 +22,7 @@ export interface OneNotePickerCallbacks {
 	// Shared notebooks have to be loaded on demand, as we only have their URLs and names
 	// to begin with. This is because getting sections for a shared notebook is expensive.
 	onSharedNotebookInfoReturned?: (sharedNotebook: SharedNotebook) => void;
+	onNotebookInfoReturned?: (notebook: Notebook) => void;
 
 	// Selection callbacks
 	onNotebookSelected?: (notebook: Notebook, breadcrumbs: OneNoteItem[]) => void;

--- a/src/providers/oneNoteApiDataProvider.ts
+++ b/src/providers/oneNoteApiDataProvider.ts
@@ -47,6 +47,12 @@ export class OneNoteApiDataProvider implements OneNoteDataProvider {
 		});
 	}
 
+	getNotebookBySelfUrl(selfUrl: string, expands?: number): Promise<Notebook> {
+		return this.api.getNotebookBySelfUrl(selfUrl, expands).then((response) => {
+			return this.responseTransformer.transformNotebook(response.parsedResponse);
+		});
+	}
+
 	getPages(section: Section): Promise<Page[]> {
 		// tslint:disable-next-line:no-any
 		return this.api.getPages({ sectionId: section.id }).then((responsePackage: OneNoteApi.ResponsePackage<any>) => {

--- a/src/providers/oneNoteDataProvider.ts
+++ b/src/providers/oneNoteDataProvider.ts
@@ -14,6 +14,7 @@ export interface OneNoteDataProvider {
 	createSectionUnderSectionGroup(parent: SectionGroup, name: string): Promise<Section>;
 
 	getNotebooks(expands?: number, excludeReadOnlyNotebooks?: boolean): Promise<Notebook[]>;
+	getNotebookBySelfUrl(selfUrl: string, expands?: number): Promise<Notebook>;
 	getPages(section: Section): Promise<Page[]>;
 
 	getSpNotebooks(): Promise<SharedNotebook[]>;


### PR DESCRIPTION
Add notebook children loading, which is needed when get notebooks fails for too many items in the sharepoint library, so we try to call get notebooks without expand. But then we need to be able to fetch the section/sectiongroups.